### PR TITLE
Add on-demand C++ function graph tools

### DIFF
--- a/docs/work/P00-function-graph-preflight.md
+++ b/docs/work/P00-function-graph-preflight.md
@@ -1,0 +1,149 @@
+# P00 Function Graph Preflight
+
+Date: 2026-06-17
+Workplan: `docs/workplans/on-demand-cpp-function-body-relation-graph.md`
+Status: complete
+
+## Implemented Phase
+
+Step 0: Repo and Contract Preflight.
+
+This phase documents ownership, target paths, dependency stance, test strategy, and non-goals before any runtime implementation begins.
+
+## Changed Files
+
+```text
+docs/workplans/on-demand-cpp-function-body-relation-graph.md
+docs/work/README.md
+docs/work/P00-function-graph-preflight.md
+```
+
+No production runtime code changed in this phase.
+
+## Runtime Owner / Module
+
+Indexer owner:
+
+```text
+src/indexer/cpp_project_index.py
+  loaded index model, symbol lookup, read_symbol, read_range, file structure, and source-range behavior
+
+src/indexer/cpp_index_sqlite.py
+  existing SQLite index path, schema initialization, symbol/data tables, and lookup indexes
+```
+
+Server owner:
+
+```text
+src/server/code_index_mcp_server.py
+  tool_definitions(...)
+  CodeIndexTools methods
+  McpServer.tool_handlers
+```
+
+Planned function graph runtime ownership:
+
+```text
+src/indexer/cpp_function_graph_*.py
+  extraction, parser adapter, visibility context, resolver, cache, storage, and service
+
+src/server/code_index_mcp_server.py
+  MCP schema, validation, response packing, and dispatch only
+```
+
+## Input / Output Contract
+
+Input:
+
+```text
+symbolId for an indexed callable symbol
+mode: cache_only | compute_if_missing | refresh
+includeControlFlow/includeDataAccess/includeExternal flags
+maxEdges
+```
+
+Output:
+
+```text
+schema id
+status and cache state
+symbol metadata
+parser/resolver metadata
+function/file/index/module/graph fingerprints
+structural edges
+claimStrength=source_structure_allowed
+behaviorClaimsAllowed=false
+```
+
+The function graph must never be behavior evidence. Behavior claims still require `read_symbol` or `read_range`.
+
+## Dependency Decision
+
+Current repo inspection found no existing Tree-sitter or pytest dependency.
+
+Decision for this preflight:
+
+```text
+Do not add parser dependencies in Step 0.
+Keep parser usage behind FunctionBodyParser.
+Step 3 must either add a pinned Tree-sitter dependency deliberately or use a test fixture parser until dependency policy is decided.
+```
+
+## Test Strategy
+
+Minimum checks for every implementation slice:
+
+```text
+python -m py_compile <touched Python files>
+targeted unit or smoke test for the slice
+git diff --check
+```
+
+Planned fixture coverage:
+
+```text
+function source extraction from indexed range
+unqualified call
+qualified call
+member call
+member assignment write
+local declaration
+same-class method resolution
+same-file static resolution
+ambiguous overload
+external Win32/STL call
+cache hit and refresh behavior
+```
+
+If a test tree is introduced, use a top-level `tests/` folder rather than placing tests under `src/indexer`.
+
+## Artifacts / Storage Evidence
+
+No runtime storage artifacts are created in Step 0.
+
+Future storage evidence must come from SQLite graph cache tables next to the existing index database, not from a separate database root or second index lifecycle.
+
+## Non-Goals Respected
+
+```text
+No second provider loop.
+No second tool loop.
+No runtime MCP tool added in preflight.
+No parser dependency added in preflight.
+No full C++ compiler semantics.
+No external API resolution.
+No behavior claims from graph data.
+No new top-level source package.
+```
+
+## Follow-Up Work
+
+Next slice: Step 1 Function Source Extraction.
+
+Expected first implementation files:
+
+```text
+src/indexer/cpp_function_graph_model.py
+src/indexer/cpp_function_graph_service.py
+tests/test_cpp_function_graph_source.py
+```

--- a/docs/work/P01-function-source-extraction.md
+++ b/docs/work/P01-function-source-extraction.md
@@ -1,0 +1,98 @@
+# P01 Function Source Extraction
+
+Date: 2026-06-17
+Workplan: `docs/workplans/on-demand-cpp-function-body-relation-graph.md`
+Status: complete
+
+## Implemented Phase
+
+Step 1: Function Source Extraction.
+
+This phase adds the first runtime slice for the function graph workplan. It resolves an indexed callable symbol to its exact source text and returns source coordinates plus a stable fingerprint.
+
+## Changed Files
+
+```text
+src/indexer/cpp_function_graph_model.py
+src/indexer/cpp_function_graph_service.py
+tests/test_cpp_function_graph_source.py
+docs/work/README.md
+docs/work/P01-function-source-extraction.md
+docs/workplans/on-demand-cpp-function-body-relation-graph.md
+```
+
+## Runtime Owner / Module
+
+Owner:
+
+```text
+src/indexer/cpp_function_graph_service.py
+```
+
+Inputs:
+
+```text
+project_root
+loaded index object with symbol_by_id and file_by_id
+symbolId for an indexed callable symbol
+```
+
+Outputs:
+
+```text
+FunctionSourceSlice
+  symbol metadata
+  fileId and relativePath
+  start/end lines
+  base line and byte offset
+  raw source text
+  functionBodyFingerprint
+```
+
+## Runtime Path
+
+```text
+FunctionGraphSourceService.extract_function_source(symbolId)
+  -> look up symbol in loaded index
+  -> reject missing or non-callable symbols
+  -> resolve fileId through file_by_id
+  -> read exact indexed source range from project_root / relativePath
+  -> compute sha256 source fingerprint
+  -> return FunctionSourceSlice
+```
+
+## Artifacts / Storage Evidence
+
+No durable storage is added in this phase.
+
+The returned `function_body_fingerprint` is the source evidence key for later AST extraction and cache phases.
+
+## Decision Authority / Governance
+
+Not applicable for this repository slice.
+
+The implementation does not add an MCP tool and does not grant behavior authority. It only extracts indexed source text.
+
+## Tests Run
+
+```text
+python -m unittest tests.test_cpp_function_graph_source
+python -m py_compile src/indexer/cpp_function_graph_model.py src/indexer/cpp_function_graph_service.py tests/test_cpp_function_graph_source.py
+git diff --check
+```
+
+## Non-Goals Respected
+
+```text
+No parser added.
+No Tree-sitter dependency added.
+No MCP tool exposed.
+No server dispatch changed.
+No cache or SQLite schema added.
+No behavior claims from graph data.
+No external API resolution.
+```
+
+## Follow-Up Work
+
+Next slice: Step 2 Data Contracts and Empty Service Shell.

--- a/docs/work/P02-data-contracts-empty-graph.md
+++ b/docs/work/P02-data-contracts-empty-graph.md
@@ -1,0 +1,111 @@
+# P02 Data Contracts and Empty Graph
+
+Date: 2026-06-17
+Workplan: `docs/workplans/on-demand-cpp-function-body-relation-graph.md`
+Status: complete
+
+## Implemented Phase
+
+Step 2: Data Contracts and Empty Service Shell.
+
+This phase extends the Step 1 source extraction slice with stable graph request/result contracts and a deterministic empty graph response.
+
+## Changed Files
+
+```text
+src/indexer/cpp_function_graph_model.py
+src/indexer/cpp_function_graph_service.py
+tests/test_cpp_function_graph_source.py
+docs/work/README.md
+docs/work/P02-data-contracts-empty-graph.md
+docs/workplans/on-demand-cpp-function-body-relation-graph.md
+```
+
+## Runtime Owner / Module
+
+Contracts:
+
+```text
+src/indexer/cpp_function_graph_model.py
+```
+
+Service:
+
+```text
+src/indexer/cpp_function_graph_service.py
+```
+
+## Runtime Path
+
+```text
+FunctionGraphSourceService.build_empty_graph_result(symbolId | FunctionGraphRequest)
+  -> extract indexed function source
+  -> create FunctionGraphFingerprints
+  -> return FunctionGraphResult with zero edges
+```
+
+## Input / Output Contract
+
+Input:
+
+```text
+FunctionGraphRequest
+  symbol_id
+  mode
+  include_control_flow
+  include_data_access
+  include_external
+  max_edges
+```
+
+Output:
+
+```text
+FunctionGraphResult
+  schema=cpp.function_body_graph.v0.1
+  status=computed
+  from_cache=false
+  symbol metadata
+  file/range metadata
+  parser/resolver metadata unset
+  claimStrength=source_structure_allowed
+  behaviorClaimsAllowed=false
+  function body and graph fingerprints
+  edges=()
+```
+
+## Artifacts / Storage Evidence
+
+No durable storage is added in this phase.
+
+The empty graph fingerprint is deterministic and derived from schema, symbol id, source fingerprint, empty edges, and unset parser/resolver metadata.
+
+## Decision Authority / Governance
+
+No MCP tool or server authority is added.
+
+The result explicitly preserves `source_structure_allowed` and `behaviorClaimsAllowed=false`.
+
+## Tests Run
+
+```text
+python -m unittest tests.test_cpp_function_graph_source
+python -m py_compile src/indexer/cpp_function_graph_model.py src/indexer/cpp_function_graph_service.py tests/test_cpp_function_graph_source.py
+git diff --check
+```
+
+## Non-Goals Respected
+
+```text
+No parser added.
+No Tree-sitter dependency added.
+No resolver added.
+No MCP tool exposed.
+No server dispatch changed.
+No cache or SQLite schema added.
+No behavior claims from graph data.
+```
+
+## Follow-Up Work
+
+Next slice: Step 3 Parser Adapter and Raw Extraction.

--- a/docs/work/P03-parser-adapter-raw-extraction.md
+++ b/docs/work/P03-parser-adapter-raw-extraction.md
@@ -1,0 +1,101 @@
+# P03 Parser Adapter and Raw Extraction
+
+Date: 2026-06-17
+Workplan: `docs/workplans/on-demand-cpp-function-body-relation-graph.md`
+Status: complete
+
+## Implemented Phase
+
+Step 3: Parser Adapter and Raw Extraction.
+
+This phase adds a parser protocol, a dependency-free lightweight raw extractor, and a Tree-sitter adapter boundary that remains unavailable until a real dependency is deliberately added.
+
+## Changed Files
+
+```text
+src/indexer/cpp_function_graph_parser.py
+src/indexer/cpp_function_graph_extract.py
+src/indexer/cpp_function_graph_tree_sitter.py
+tests/test_cpp_function_graph_extract.py
+docs/work/README.md
+docs/work/P03-parser-adapter-raw-extraction.md
+docs/workplans/on-demand-cpp-function-body-relation-graph.md
+```
+
+## Runtime Owner / Module
+
+Parser protocol:
+
+```text
+src/indexer/cpp_function_graph_parser.py
+```
+
+Raw extraction:
+
+```text
+src/indexer/cpp_function_graph_extract.py
+```
+
+Tree-sitter boundary:
+
+```text
+src/indexer/cpp_function_graph_tree_sitter.py
+```
+
+## Runtime Path
+
+```text
+LightweightFunctionBodyParser.parse_function(...)
+  -> extract_raw_function_ast(...)
+  -> FunctionAstExtract(calls, member_accesses, local_declarations, control_flow)
+```
+
+The extractor maps each occurrence back to original file coordinates using `base_line` and `base_byte`.
+
+## Extracted Facts
+
+```text
+calls:
+  callee text, callKind, argumentCount, line, column, byte
+
+member_accesses:
+  text, read/write candidate, line, column, byte
+
+local_declarations:
+  name, typeText, line, column, byte
+
+control_flow:
+  marker, line, column, byte
+```
+
+These are structural syntax facts only. They do not resolve project symbols or support behavior claims.
+
+## Dependency Decision
+
+No Tree-sitter dependency was added in this phase.
+
+`TreeSitterCppFunctionBodyParser` raises `TreeSitterUnavailableError` at construction time. This preserves the adapter seam without pretending Tree-sitter is configured.
+
+## Tests Run
+
+```text
+python -m unittest tests.test_cpp_function_graph_source tests.test_cpp_function_graph_extract
+python -m py_compile src/indexer/cpp_function_graph_model.py src/indexer/cpp_function_graph_service.py src/indexer/cpp_function_graph_parser.py src/indexer/cpp_function_graph_extract.py src/indexer/cpp_function_graph_tree_sitter.py tests/test_cpp_function_graph_source.py tests/test_cpp_function_graph_extract.py
+git diff --check
+```
+
+## Non-Goals Respected
+
+```text
+No Tree-sitter dependency added.
+No resolver added.
+No MCP tool exposed.
+No server dispatch changed.
+No cache or SQLite schema added.
+No behavior claims from graph data.
+No external API resolution.
+```
+
+## Follow-Up Work
+
+Next slice: Step 4 Visibility Context.

--- a/docs/work/P04-visibility-context.md
+++ b/docs/work/P04-visibility-context.md
@@ -1,0 +1,103 @@
+# P04 Visibility Context
+
+Date: 2026-06-17
+Workplan: `docs/workplans/on-demand-cpp-function-body-relation-graph.md`
+Status: complete
+
+## Implemented Phase
+
+Step 4: Visibility Context.
+
+This phase builds a function-local visibility context from existing project index data. It does not resolve calls yet.
+
+## Changed Files
+
+```text
+src/indexer/cpp_function_graph_model.py
+src/indexer/cpp_function_graph_visibility.py
+tests/test_cpp_function_graph_visibility.py
+docs/work/README.md
+docs/work/P04-visibility-context.md
+docs/workplans/on-demand-cpp-function-body-relation-graph.md
+```
+
+## Runtime Owner / Module
+
+```text
+src/indexer/cpp_function_graph_visibility.py
+```
+
+## Runtime Path
+
+```text
+build_function_visibility_context(index, source, ast_extract)
+  -> load current function symbol
+  -> collect same-file symbols and data
+  -> derive current namespace and current class
+  -> find current class symbol
+  -> collect module membership and visible module symbols
+  -> collect member data for current class
+  -> carry local declarations from raw AST extract
+  -> return FunctionVisibilityContext
+```
+
+## Input / Output Contract
+
+Input:
+
+```text
+loaded index object
+FunctionSourceSlice
+optional FunctionAstExtract
+```
+
+Output:
+
+```text
+FunctionVisibilityContext
+  file id/path
+  function symbol id
+  current namespace
+  current class symbol/name
+  imported module names
+  visible module symbols
+  same-file symbols
+  same-file data
+  member data
+  local declarations
+  empty using declaration/directive and namespace alias candidates for later phases
+```
+
+## Artifacts / Storage Evidence
+
+No durable storage is added in this phase.
+
+## Decision Authority / Governance
+
+No MCP tool or runtime authority is added.
+
+The visibility context is metadata for later structural resolution. It is not behavior evidence.
+
+## Tests Run
+
+```text
+python -m unittest tests.test_cpp_function_graph_source tests.test_cpp_function_graph_extract tests.test_cpp_function_graph_visibility
+python -m py_compile src/indexer/cpp_function_graph_model.py src/indexer/cpp_function_graph_service.py src/indexer/cpp_function_graph_parser.py src/indexer/cpp_function_graph_extract.py src/indexer/cpp_function_graph_tree_sitter.py src/indexer/cpp_function_graph_visibility.py tests/test_cpp_function_graph_source.py tests/test_cpp_function_graph_extract.py tests/test_cpp_function_graph_visibility.py
+git diff --check
+```
+
+## Non-Goals Respected
+
+```text
+No resolver added.
+No MCP tool exposed.
+No server dispatch changed.
+No cache or SQLite schema added.
+No behavior claims from graph data.
+No external API resolution.
+No full C++ visibility semantics.
+```
+
+## Follow-Up Work
+
+Next slice: Step 5 Project-Only Resolver v0.1.

--- a/docs/work/P05-project-only-resolver.md
+++ b/docs/work/P05-project-only-resolver.md
@@ -1,0 +1,101 @@
+# P05 Project-Only Resolver
+
+Date: 2026-06-17
+Workplan: `docs/workplans/on-demand-cpp-function-body-relation-graph.md`
+Status: complete
+
+## Implemented Phase
+
+Step 5: Project-Only Resolver v0.1.
+
+This phase resolves raw call occurrences against the function-local visibility context. It does not persist edges or expose MCP tools.
+
+## Changed Files
+
+```text
+src/indexer/cpp_function_graph_model.py
+src/indexer/cpp_function_graph_resolver.py
+tests/test_cpp_function_graph_resolver.py
+docs/work/README.md
+docs/work/P05-project-only-resolver.md
+docs/workplans/on-demand-cpp-function-body-relation-graph.md
+```
+
+## Runtime Owner / Module
+
+```text
+src/indexer/cpp_function_graph_resolver.py
+```
+
+## Runtime Path
+
+```text
+resolve_function_graph_edges(ast_extract, visibility)
+  -> iterate raw call occurrences
+  -> resolve qualified calls by exact qualified name
+  -> resolve this->member calls against current class
+  -> resolve unqualified calls against current class, same namespace/file, and module-visible symbols
+  -> return FunctionGraphEdge entries
+```
+
+## Resolution Contract
+
+```text
+single exact qualified/this match:
+  resolution_status=exact
+  edge_kind=calls_resolved
+
+single unqualified project-local match:
+  resolution_status=probable
+  edge_kind=calls_candidate
+
+multiple project-local matches:
+  resolution_status=ambiguous
+  edge_kind=calls_ambiguous
+  candidates populated
+
+member call without object type:
+  resolution_status=unresolved
+  edge_kind=calls_unresolved
+
+no project candidate:
+  resolution_status=external
+  edge_kind=calls_external
+```
+
+## Artifacts / Storage Evidence
+
+No durable storage is added in this phase.
+
+Edges are returned in memory only.
+
+## Decision Authority / Governance
+
+No MCP tool or server authority is added.
+
+All edges keep `claimStrength=source_structure_allowed` and `behaviorClaimsAllowed=false`.
+
+## Tests Run
+
+```text
+python -m unittest tests.test_cpp_function_graph_source tests.test_cpp_function_graph_extract tests.test_cpp_function_graph_visibility tests.test_cpp_function_graph_resolver
+python -m py_compile src/indexer/cpp_function_graph_model.py src/indexer/cpp_function_graph_service.py src/indexer/cpp_function_graph_parser.py src/indexer/cpp_function_graph_extract.py src/indexer/cpp_function_graph_tree_sitter.py src/indexer/cpp_function_graph_visibility.py src/indexer/cpp_function_graph_resolver.py tests/test_cpp_function_graph_source.py tests/test_cpp_function_graph_extract.py tests/test_cpp_function_graph_visibility.py tests/test_cpp_function_graph_resolver.py
+git diff --check
+```
+
+## Non-Goals Respected
+
+```text
+No full overload resolution.
+No template instantiation.
+No ADL semantics.
+No external API resolution.
+No MCP tool exposed.
+No server dispatch changed.
+No cache or SQLite schema added.
+No behavior claims from graph data.
+```
+
+## Follow-Up Work
+
+Next slice: Step 6 Cache and SQLite Storage.

--- a/docs/work/P06-cache-sqlite-storage.md
+++ b/docs/work/P06-cache-sqlite-storage.md
@@ -1,0 +1,124 @@
+# P06 Cache and SQLite Storage
+
+Date: 2026-06-17
+Workplan: `docs/workplans/on-demand-cpp-function-body-relation-graph.md`
+Status: complete
+
+## Implemented Phase
+
+Step 6: Cache and SQLite Storage.
+
+This phase adds AST extract cache keys, graph resolution cache keys, and SQLite-backed storage tables in the existing index database file.
+
+## Changed Files
+
+```text
+src/indexer/cpp_function_graph_cache.py
+src/indexer/cpp_function_graph_storage.py
+tests/test_cpp_function_graph_storage.py
+docs/work/README.md
+docs/work/P06-cache-sqlite-storage.md
+docs/workplans/on-demand-cpp-function-body-relation-graph.md
+```
+
+## Runtime Owner / Module
+
+Cache keys:
+
+```text
+src/indexer/cpp_function_graph_cache.py
+```
+
+Storage:
+
+```text
+src/indexer/cpp_function_graph_storage.py
+```
+
+The storage helper uses `cpp_index_sqlite.sqlite_index_path(index_root)`, so graph data is stored next to the existing lookup tables in `index.sqlite`.
+
+## Runtime Path
+
+```text
+FunctionGraphStorage.from_index_root(index_root)
+  -> existing index.sqlite path
+  -> initialize function graph tables if missing
+
+store_ast_extract/load_ast_extract
+  -> function_ast_extract_cache
+
+store_graph_result/load_graph_result
+  -> function_graph_cache
+  -> function_graph_edges
+
+list_edges_from/list_edges_to
+  -> persisted edge rows for later xref tools
+```
+
+## Cache Contract
+
+AST extract cache key:
+
+```text
+function_symbol_id
+function_body_fingerprint
+parser_id
+parser_version
+extractor_version
+```
+
+Graph resolution cache key:
+
+```text
+function_symbol_id
+function_body_fingerprint
+file_fingerprint
+symbol_index_fingerprint
+module_visibility_fingerprint
+parser_id
+parser_version
+resolver_version
+```
+
+Changing module visibility, symbol index, parser, or resolver fingerprints causes a cache miss.
+
+## Artifacts / Storage Evidence
+
+SQLite tables:
+
+```text
+function_ast_extract_cache
+function_graph_cache
+function_graph_edges
+```
+
+No separate database root is introduced.
+
+## Decision Authority / Governance
+
+No MCP tool or server authority is added.
+
+Persisted graph edges retain `claim_strength` and `behavior_claims_allowed`.
+
+## Tests Run
+
+```text
+python -m unittest tests.test_cpp_function_graph_source tests.test_cpp_function_graph_extract tests.test_cpp_function_graph_visibility tests.test_cpp_function_graph_resolver tests.test_cpp_function_graph_storage
+python -m py_compile src/indexer/cpp_function_graph_model.py src/indexer/cpp_function_graph_service.py src/indexer/cpp_function_graph_parser.py src/indexer/cpp_function_graph_extract.py src/indexer/cpp_function_graph_tree_sitter.py src/indexer/cpp_function_graph_visibility.py src/indexer/cpp_function_graph_resolver.py src/indexer/cpp_function_graph_cache.py src/indexer/cpp_function_graph_storage.py tests/test_cpp_function_graph_source.py tests/test_cpp_function_graph_extract.py tests/test_cpp_function_graph_visibility.py tests/test_cpp_function_graph_resolver.py tests/test_cpp_function_graph_storage.py
+git diff --check
+```
+
+## Non-Goals Respected
+
+```text
+No MCP tool exposed.
+No server dispatch changed.
+No separate database root.
+No second index lifecycle.
+No behavior claims from graph data.
+No external API resolution.
+```
+
+## Follow-Up Work
+
+Next slice: Step 7 MCP Tool `get_function_body_graph`.

--- a/docs/work/P07-mcp-get-function-body-graph.md
+++ b/docs/work/P07-mcp-get-function-body-graph.md
@@ -1,0 +1,149 @@
+# P07 MCP get_function_body_graph
+
+Date: 2026-06-17
+Workplan: `docs/workplans/on-demand-cpp-function-body-relation-graph.md`
+Status: complete
+
+## Implemented Phase
+
+Step 7: MCP Tool `get_function_body_graph`.
+
+This phase exposes the first on-demand function graph tool through the existing MCP server while keeping parsing, resolution, and cache ownership in `src/indexer`.
+
+## Changed Files
+
+```text
+src/indexer/cpp_function_graph_service.py
+src/server/code_index_mcp_server.py
+tests/test_cpp_function_graph_source.py
+tests/test_cpp_function_graph_mcp_schema.py
+docs/work/README.md
+docs/work/P07-mcp-get-function-body-graph.md
+docs/workplans/on-demand-cpp-function-body-relation-graph.md
+```
+
+## Runtime Owner / Module
+
+MCP schema, argument validation, and dispatch:
+
+```text
+src/server/code_index_mcp_server.py
+```
+
+Function graph runtime:
+
+```text
+src/indexer/cpp_function_graph_service.py
+src/indexer/cpp_function_graph_extract.py
+src/indexer/cpp_function_graph_visibility.py
+src/indexer/cpp_function_graph_resolver.py
+src/indexer/cpp_function_graph_storage.py
+```
+
+## Runtime Path
+
+```text
+get_function_body_graph(symbolId, mode)
+  -> CodeIndexTools validates MCP args
+  -> CodeIndexTools computes file/symbol/module visibility fingerprints
+  -> FunctionGraphSourceService extracts indexed function text
+  -> AST extract cache lookup
+  -> lightweight parser on cache miss
+  -> visibility context from existing index data
+  -> project-only resolver
+  -> graph cache store/load in existing index.sqlite
+  -> compact MCP JSON response
+```
+
+## Public API
+
+First MCP v1 tool:
+
+```text
+get_function_body_graph
+```
+
+Modes:
+
+```text
+cache_only
+compute_if_missing
+refresh
+```
+
+Output includes:
+
+```text
+schema
+status
+fromCache
+symbolId
+functionName
+qualifiedName
+parser/resolver metadata
+fingerprints
+edges
+claimStrength=source_structure_allowed
+behaviorClaimsAllowed=false
+```
+
+## Artifacts / Storage Evidence
+
+Graph results are backed by:
+
+```text
+functionBody fingerprint
+file fingerprint
+symbolIndex fingerprint
+moduleVisibility fingerprint
+graph fingerprint
+```
+
+Computed graph results are stored in the existing `index.sqlite` function graph tables from Step 6.
+
+## Decision Authority / Governance
+
+No provider loop, tool loop, or governance path is introduced.
+
+The tool is structural only:
+
+```text
+claimStrength=source_structure_allowed
+behaviorClaimsAllowed=false
+```
+
+Behavior claims still require source-read tools such as `read_symbol` or `read_range`.
+
+## Tests Run
+
+```text
+python -m unittest tests.test_cpp_function_graph_source tests.test_cpp_function_graph_extract tests.test_cpp_function_graph_visibility tests.test_cpp_function_graph_resolver tests.test_cpp_function_graph_storage tests.test_cpp_function_graph_mcp_schema
+python -m py_compile src/indexer/cpp_function_graph_model.py src/indexer/cpp_function_graph_service.py src/indexer/cpp_function_graph_parser.py src/indexer/cpp_function_graph_extract.py src/indexer/cpp_function_graph_tree_sitter.py src/indexer/cpp_function_graph_visibility.py src/indexer/cpp_function_graph_resolver.py src/indexer/cpp_function_graph_cache.py src/indexer/cpp_function_graph_storage.py src/server/code_index_mcp_server.py tests/test_cpp_function_graph_source.py tests/test_cpp_function_graph_extract.py tests/test_cpp_function_graph_visibility.py tests/test_cpp_function_graph_resolver.py tests/test_cpp_function_graph_storage.py tests/test_cpp_function_graph_mcp_schema.py
+git diff --check
+```
+
+Result:
+
+```text
+Ran 18 tests - OK
+py_compile - OK
+git diff --check - OK
+```
+
+## Non-Goals Respected
+
+```text
+No get_call_xrefs_from tool added.
+No get_call_xrefs_to tool added.
+No get_symbol_neighborhood tool added.
+No parser or resolver logic added to the MCP server.
+No external API semantic resolution.
+No behavior claims from graph data.
+No second provider loop.
+No second tool loop.
+No broad helper library or new top-level package.
+```
+
+## Follow-Up Work
+
+Next slice: Step 8 Xrefs and Neighborhood, using persisted edges from Step 6/7.

--- a/docs/work/P08-xrefs-neighborhood.md
+++ b/docs/work/P08-xrefs-neighborhood.md
@@ -1,0 +1,124 @@
+# P08 Xrefs and Neighborhood
+
+Date: 2026-06-17
+Workplan: `docs/workplans/on-demand-cpp-function-body-relation-graph.md`
+Status: complete
+
+## Implemented Phase
+
+Step 8: Xrefs and Neighborhood.
+
+This phase exposes persisted function graph edges in both directions and adds a compact symbol neighborhood view. The tools read stored edges only; they do not compute missing graphs.
+
+## Changed Files
+
+```text
+src/indexer/cpp_function_graph_storage.py
+src/indexer/cpp_function_graph_service.py
+src/server/code_index_mcp_server.py
+tests/test_cpp_function_graph_source.py
+tests/test_cpp_function_graph_storage.py
+tests/test_cpp_function_graph_mcp_schema.py
+docs/work/README.md
+docs/work/P08-xrefs-neighborhood.md
+docs/workplans/on-demand-cpp-function-body-relation-graph.md
+```
+
+## Runtime Owner / Module
+
+Persisted edge lookup:
+
+```text
+src/indexer/cpp_function_graph_storage.py
+```
+
+Xref and neighborhood service API:
+
+```text
+src/indexer/cpp_function_graph_service.py
+```
+
+MCP schema, validation, and dispatch:
+
+```text
+src/server/code_index_mcp_server.py
+```
+
+## Runtime Path
+
+```text
+get_call_xrefs_from(symbolId)
+  -> read persisted function_graph_edges by from_symbol_id
+
+get_call_xrefs_to(symbolId)
+  -> read persisted function_graph_edges by to_symbol_id
+
+get_symbol_neighborhood(symbolId)
+  -> read persisted incoming and outgoing edges
+  -> return target, callers, callees, and compact edge sets
+```
+
+## Public API
+
+New MCP tools:
+
+```text
+get_call_xrefs_from
+get_call_xrefs_to
+get_symbol_neighborhood
+```
+
+All three tools return structural navigation data only:
+
+```text
+claimStrength=source_structure_allowed
+behaviorClaimsAllowed=false
+```
+
+## Artifacts / Storage Evidence
+
+The tools read from the Step 6/7 SQLite storage:
+
+```text
+function_graph_edges
+```
+
+When a new graph result is stored for a function, outgoing rows for that function are replaced so xref tools do not surface stale outgoing edges from older graph fingerprints.
+
+## Decision Authority / Governance
+
+No provider loop, tool loop, or governance path is introduced.
+
+The tools expose persisted structural relationships only. They do not parse source, resolve external APIs semantically, or support behavior claims.
+
+## Tests Run
+
+```text
+python -m unittest tests.test_cpp_function_graph_source tests.test_cpp_function_graph_extract tests.test_cpp_function_graph_visibility tests.test_cpp_function_graph_resolver tests.test_cpp_function_graph_storage tests.test_cpp_function_graph_mcp_schema
+python -m py_compile src/indexer/cpp_function_graph_model.py src/indexer/cpp_function_graph_service.py src/indexer/cpp_function_graph_parser.py src/indexer/cpp_function_graph_extract.py src/indexer/cpp_function_graph_tree_sitter.py src/indexer/cpp_function_graph_visibility.py src/indexer/cpp_function_graph_resolver.py src/indexer/cpp_function_graph_cache.py src/indexer/cpp_function_graph_storage.py src/server/code_index_mcp_server.py tests/test_cpp_function_graph_source.py tests/test_cpp_function_graph_extract.py tests/test_cpp_function_graph_visibility.py tests/test_cpp_function_graph_resolver.py tests/test_cpp_function_graph_storage.py tests/test_cpp_function_graph_mcp_schema.py
+git diff --check
+```
+
+Result:
+
+```text
+Ran 20 tests - OK
+py_compile - OK
+git diff --check - OK
+```
+
+## Non-Goals Respected
+
+```text
+No missing graph computation in xref tools.
+No recursive graph expansion.
+No behavior claims from graph data.
+No external API semantic resolution.
+No second provider loop.
+No second tool loop.
+No broad helper library or new top-level package.
+```
+
+## Follow-Up Work
+
+Next slice: Step 9 Resolution Improvements.

--- a/docs/work/P09-resolution-improvements.md
+++ b/docs/work/P09-resolution-improvements.md
@@ -1,0 +1,115 @@
+# P09 Resolution Improvements
+
+Date: 2026-06-17
+Workplan: `docs/workplans/on-demand-cpp-function-body-relation-graph.md`
+Status: complete
+
+## Implemented Phase
+
+Step 9: Resolution Improvements.
+
+This phase improves project-local candidate quality for function graph resolution without claiming compiler-level C++ semantics.
+
+## Changed Files
+
+```text
+src/indexer/cpp_function_graph_visibility.py
+src/indexer/cpp_function_graph_resolver.py
+tests/test_cpp_function_graph_visibility.py
+tests/test_cpp_function_graph_resolver.py
+docs/work/README.md
+docs/work/P09-resolution-improvements.md
+docs/workplans/on-demand-cpp-function-body-relation-graph.md
+```
+
+## Runtime Owner / Module
+
+Visibility context:
+
+```text
+src/indexer/cpp_function_graph_visibility.py
+```
+
+Project-only resolver:
+
+```text
+src/indexer/cpp_function_graph_resolver.py
+```
+
+## Runtime Path
+
+```text
+FunctionGraphSourceService
+  -> build_function_visibility_context
+     -> optional using declarations/directives and namespace aliases from index metadata
+  -> resolve_function_graph_edges
+     -> namespace alias expansion for qualified calls
+     -> using declaration / using namespace candidates for unqualified calls
+     -> simple local type hint for member calls
+     -> arity-based candidate scoring
+```
+
+## Resolution Contract
+
+Added candidate-quality signals:
+
+```text
+using_declaration
+using_namespace
+namespace_alias
+local_type_hint
+arity_match
+arity_mismatch
+```
+
+Ambiguous overloads remain ambiguous. Scores sort candidates; they do not create fake exact matches.
+
+## Artifacts / Storage Evidence
+
+Stored graph edges continue to carry:
+
+```text
+claimStrength=source_structure_allowed
+behaviorClaimsAllowed=false
+```
+
+Candidate refs may now include score and basis fields when ambiguity requires ranking.
+
+## Decision Authority / Governance
+
+No MCP schema or dispatch change is added in this phase.
+
+No provider loop, tool loop, or governance path is introduced.
+
+## Tests Run
+
+```text
+python -m unittest tests.test_cpp_function_graph_source tests.test_cpp_function_graph_extract tests.test_cpp_function_graph_visibility tests.test_cpp_function_graph_resolver tests.test_cpp_function_graph_storage tests.test_cpp_function_graph_mcp_schema
+python -m py_compile src/indexer/cpp_function_graph_model.py src/indexer/cpp_function_graph_service.py src/indexer/cpp_function_graph_parser.py src/indexer/cpp_function_graph_extract.py src/indexer/cpp_function_graph_tree_sitter.py src/indexer/cpp_function_graph_visibility.py src/indexer/cpp_function_graph_resolver.py src/indexer/cpp_function_graph_cache.py src/indexer/cpp_function_graph_storage.py src/server/code_index_mcp_server.py tests/test_cpp_function_graph_source.py tests/test_cpp_function_graph_extract.py tests/test_cpp_function_graph_visibility.py tests/test_cpp_function_graph_resolver.py tests/test_cpp_function_graph_storage.py tests/test_cpp_function_graph_mcp_schema.py
+git diff --check
+```
+
+Result:
+
+```text
+Ran 24 tests - OK
+py_compile - OK
+git diff --check - OK
+```
+
+## Non-Goals Respected
+
+```text
+No full overload resolution.
+No ADL.
+No template instantiation.
+No external API semantic resolution.
+No behavior claims from graph data.
+No MCP tool expansion.
+No second provider loop.
+No second tool loop.
+```
+
+## Follow-Up Work
+
+Initial workplan implementation slices are complete except optional future work such as vector sidecar or broader parser dependency decisions.

--- a/docs/work/P10-optional-vector-sidecar-deferred.md
+++ b/docs/work/P10-optional-vector-sidecar-deferred.md
@@ -1,0 +1,93 @@
+# P10 Optional Vector Sidecar Deferred
+
+Date: 2026-06-17
+Workplan: `docs/workplans/completed/on-demand-cpp-function-body-relation-graph.md`
+Status: deferred
+
+## Implemented Phase
+
+Step 10: Optional Vector Sidecar.
+
+No runtime implementation was added. The workplan explicitly defines this step as future work only.
+
+## Changed Files
+
+```text
+docs/work/README.md
+docs/work/P10-optional-vector-sidecar-deferred.md
+docs/workplans/on-demand-cpp-function-body-relation-graph.md
+docs/workplans/README.md
+```
+
+## Runtime Owner / Module
+
+No runtime owner is introduced.
+
+Future vector sidecar work, if accepted later, must remain outside behavior evidence:
+
+```text
+vector sidecar -> routing_hint_only
+function graph -> source_structure_allowed
+source reads -> source_behavior_allowed
+```
+
+## Runtime Path
+
+No runtime path is added.
+
+The current initial implementation remains:
+
+```text
+get_function_body_graph
+  -> on-demand source extraction
+  -> parser adapter
+  -> project-only resolver
+  -> graph cache
+
+get_call_xrefs_from / get_call_xrefs_to / get_symbol_neighborhood
+  -> persisted graph edges only
+```
+
+## Artifacts / Storage Evidence
+
+No vector tables, embeddings, sidecar files, or warmup jobs are added.
+
+Existing evidence remains the SQLite function graph cache and edge tables from Steps 6-8.
+
+## Decision Authority / Governance
+
+No provider loop, tool loop, governance path, or model/provider behavior is changed.
+
+No vector output can be used as behavior evidence.
+
+## Tests Run
+
+```text
+python -m unittest tests.test_cpp_function_graph_source tests.test_cpp_function_graph_extract tests.test_cpp_function_graph_visibility tests.test_cpp_function_graph_resolver tests.test_cpp_function_graph_storage tests.test_cpp_function_graph_mcp_schema
+python -m py_compile src/indexer/cpp_function_graph_model.py src/indexer/cpp_function_graph_service.py src/indexer/cpp_function_graph_parser.py src/indexer/cpp_function_graph_extract.py src/indexer/cpp_function_graph_tree_sitter.py src/indexer/cpp_function_graph_visibility.py src/indexer/cpp_function_graph_resolver.py src/indexer/cpp_function_graph_cache.py src/indexer/cpp_function_graph_storage.py src/server/code_index_mcp_server.py tests/test_cpp_function_graph_source.py tests/test_cpp_function_graph_extract.py tests/test_cpp_function_graph_visibility.py tests/test_cpp_function_graph_resolver.py tests/test_cpp_function_graph_storage.py tests/test_cpp_function_graph_mcp_schema.py
+git diff --check
+```
+
+Result:
+
+```text
+Ran 24 tests - OK
+py_compile - OK
+git diff --check - OK
+```
+
+## Non-Goals Respected
+
+```text
+No vector sidecar implementation.
+No embedding dependency.
+No background warmup job.
+No new MCP tool.
+No behavior claims from routing hints.
+No second provider loop.
+No second tool loop.
+```
+
+## Completion Note
+
+The initial function-body graph workplan is complete after Steps 0-9 plus this explicit Step 10 deferral.

--- a/docs/work/P11-data-control-flow-edges.md
+++ b/docs/work/P11-data-control-flow-edges.md
@@ -1,0 +1,113 @@
+# P11 Data and Control-Flow Edges
+
+Date: 2026-06-17
+Workplan: `docs/workplans/completed/function-graph-edge-expansion.md`
+Status: complete
+
+## Implemented Phase
+
+Function Graph Edge Expansion Step 1: Data and Control-Flow Edges.
+
+This slice exposes already-extracted raw member/data accesses and control-flow markers as structural graph edges.
+
+## Changed Files
+
+```text
+src/indexer/cpp_function_graph_resolver.py
+src/indexer/cpp_function_graph_service.py
+tests/test_cpp_function_graph_resolver.py
+docs/work/README.md
+docs/work/P11-data-control-flow-edges.md
+docs/workplans/README.md
+docs/workplans/function-graph-edge-expansion.md
+```
+
+## Runtime Owner / Module
+
+Resolver:
+
+```text
+src/indexer/cpp_function_graph_resolver.py
+```
+
+Service/cache option wiring:
+
+```text
+src/indexer/cpp_function_graph_service.py
+```
+
+## Runtime Path
+
+```text
+get_function_body_graph
+  -> FunctionGraphSourceService
+  -> resolve_function_graph_edges(
+       includeDataAccess,
+       includeControlFlow
+     )
+  -> calls + optional data access edges + optional control-flow marker edges
+```
+
+## Edge Contract
+
+Data access edges:
+
+```text
+reads_data_candidate
+writes_data_candidate
+```
+
+Control-flow edges:
+
+```text
+control_flow_marker
+```
+
+All emitted edges retain:
+
+```text
+claimStrength=source_structure_allowed
+behaviorClaimsAllowed=false
+```
+
+## Cache Contract
+
+Graph cache lookup now includes the relevant graph options in the resolver cache-version string:
+
+```text
+includeControlFlow
+includeDataAccess
+includeExternal
+maxEdges
+```
+
+This prevents cache reuse across incompatible graph-output shapes without changing the SQLite schema.
+
+## Tests Run
+
+```text
+python -m unittest discover -s tests -p "test_*.py"
+python -m py_compile src/indexer/cpp_function_graph_model.py src/indexer/cpp_function_graph_service.py src/indexer/cpp_function_graph_parser.py src/indexer/cpp_function_graph_extract.py src/indexer/cpp_function_graph_tree_sitter.py src/indexer/cpp_function_graph_visibility.py src/indexer/cpp_function_graph_resolver.py src/indexer/cpp_function_graph_cache.py src/indexer/cpp_function_graph_storage.py src/server/code_index_mcp_server.py tests/test_cpp_function_graph_source.py tests/test_cpp_function_graph_extract.py tests/test_cpp_function_graph_visibility.py tests/test_cpp_function_graph_resolver.py tests/test_cpp_function_graph_storage.py tests/test_cpp_function_graph_mcp_schema.py
+temporary real-index smoke with CodeIndexTools.get_function_body_graph(includeDataAccess/includeControlFlow)
+```
+
+Result:
+
+```text
+Ran 26 tests - OK
+py_compile - OK
+real-index smoke - OK
+```
+
+## Non-Goals Respected
+
+```text
+No Tree-sitter dependency change.
+No new MCP tool.
+No vector sidecar.
+No full CFG.
+No data-flow semantics.
+No behavior claims from graph data.
+No second provider loop.
+No second tool loop.
+```

--- a/docs/work/P12-real-index-mcp-smoke.md
+++ b/docs/work/P12-real-index-mcp-smoke.md
@@ -1,0 +1,67 @@
+# P12 Real Index MCP Smoke
+
+Date: 2026-06-17
+Workplan: `docs/workplans/completed/function-graph-edge-expansion.md`
+Status: complete
+
+## Implemented Phase
+
+Follow-up hardening: persist the temporary real-index MCP smoke as a regression test.
+
+## Changed Files
+
+```text
+tests/test_cpp_function_graph_mcp_smoke.py
+docs/work/README.md
+docs/work/P12-real-index-mcp-smoke.md
+```
+
+## Runtime Owner / Module
+
+No production runtime code changed.
+
+The smoke covers:
+
+```text
+build_project_index.py
+CodeIndexTools.find_symbol
+CodeIndexTools.get_function_body_graph
+CodeIndexTools.get_call_xrefs_from
+```
+
+## Smoke Contract
+
+The test builds a temporary C++ project and verifies:
+
+```text
+definition symbol is selected instead of method declaration
+get_function_body_graph computes a structural graph
+cache_only returns the same graph fingerprint from cache
+xrefs read persisted outgoing edges
+data/control-flow edges are emitted by default
+data/control-flow edges are removed by includeDataAccess=false and includeControlFlow=false
+behaviorClaimsAllowed=false
+```
+
+## Tests Run
+
+```text
+python -m unittest tests.test_cpp_function_graph_mcp_smoke
+python -m unittest discover -s tests -p "test_*.py"
+```
+
+Result:
+
+```text
+smoke test - OK
+Ran 27 tests - OK
+```
+
+## Non-Goals Respected
+
+```text
+No production behavior change.
+No new MCP tool.
+No external service dependency.
+No behavior claims from graph data.
+```

--- a/docs/work/README.md
+++ b/docs/work/README.md
@@ -16,6 +16,7 @@ This folder records implemented or prepared work slices for active workplans.
 - [P09 Resolution Improvements](P09-resolution-improvements.md) - Step 9 using/alias/local type hint and overload scoring improvements.
 - [P10 Optional Vector Sidecar Deferred](P10-optional-vector-sidecar-deferred.md) - Step 10 explicit future-work deferral, no runtime implementation.
 - [P11 Data and Control-Flow Edges](P11-data-control-flow-edges.md) - graph edge expansion for data access and control-flow markers.
+- [P12 Real Index MCP Smoke](P12-real-index-mcp-smoke.md) - persisted real-index CodeIndexTools smoke for graph/cache/xref edges.
 
 ## Completed Logs
 

--- a/docs/work/README.md
+++ b/docs/work/README.md
@@ -15,6 +15,7 @@ This folder records implemented or prepared work slices for active workplans.
 - [P08 Xrefs and Neighborhood](P08-xrefs-neighborhood.md) - Step 8 persisted caller/callee xrefs and compact symbol neighborhood.
 - [P09 Resolution Improvements](P09-resolution-improvements.md) - Step 9 using/alias/local type hint and overload scoring improvements.
 - [P10 Optional Vector Sidecar Deferred](P10-optional-vector-sidecar-deferred.md) - Step 10 explicit future-work deferral, no runtime implementation.
+- [P11 Data and Control-Flow Edges](P11-data-control-flow-edges.md) - graph edge expansion for data access and control-flow markers.
 
 ## Completed Logs
 

--- a/docs/work/README.md
+++ b/docs/work/README.md
@@ -1,0 +1,21 @@
+# Work Logs
+
+This folder records implemented or prepared work slices for active workplans.
+
+## Active Logs
+
+- [P00 Function Graph Preflight](P00-function-graph-preflight.md) - preflight for `docs/workplans/on-demand-cpp-function-body-relation-graph.md`.
+- [P01 Function Source Extraction](P01-function-source-extraction.md) - Step 1 runtime slice for indexed function source extraction.
+- [P02 Data Contracts and Empty Graph](P02-data-contracts-empty-graph.md) - Step 2 contracts and empty graph result shell.
+- [P03 Parser Adapter and Raw Extraction](P03-parser-adapter-raw-extraction.md) - Step 3 parser protocol, lightweight extractor, and Tree-sitter isolation.
+- [P04 Visibility Context](P04-visibility-context.md) - Step 4 function-local visibility context from existing index data.
+- [P05 Project-Only Resolver](P05-project-only-resolver.md) - Step 5 project-local call resolver v0.1.
+- [P06 Cache and SQLite Storage](P06-cache-sqlite-storage.md) - Step 6 AST/graph caches and persisted graph edges in the existing index database.
+- [P07 MCP get_function_body_graph](P07-mcp-get-function-body-graph.md) - Step 7 first MCP function graph tool and compact structural response.
+- [P08 Xrefs and Neighborhood](P08-xrefs-neighborhood.md) - Step 8 persisted caller/callee xrefs and compact symbol neighborhood.
+- [P09 Resolution Improvements](P09-resolution-improvements.md) - Step 9 using/alias/local type hint and overload scoring improvements.
+- [P10 Optional Vector Sidecar Deferred](P10-optional-vector-sidecar-deferred.md) - Step 10 explicit future-work deferral, no runtime implementation.
+
+## Completed Logs
+
+- Function graph workplan logs P00-P10 are complete for the initial implementation.

--- a/docs/workplans/README.md
+++ b/docs/workplans/README.md
@@ -7,3 +7,4 @@ None.
 ## Completed
 
 - [On-Demand C++ Function Body Relation Graph](completed/on-demand-cpp-function-body-relation-graph.md) - completed initial implementation, 2026-06-17.
+- [Function Graph Edge Expansion](completed/function-graph-edge-expansion.md) - completed data/control-flow edge follow-up, 2026-06-17.

--- a/docs/workplans/README.md
+++ b/docs/workplans/README.md
@@ -1,0 +1,9 @@
+# Workplans
+
+## Active
+
+None.
+
+## Completed
+
+- [On-Demand C++ Function Body Relation Graph](completed/on-demand-cpp-function-body-relation-graph.md) - completed initial implementation, 2026-06-17.

--- a/docs/workplans/completed/function-graph-edge-expansion.md
+++ b/docs/workplans/completed/function-graph-edge-expansion.md
@@ -1,0 +1,79 @@
+# Workplan: Function Graph Edge Expansion
+
+Date: 2026-06-17
+Status: completed
+Component: C++ MCP Project Indexer
+
+## Goal
+
+Extend the completed on-demand function-body graph with the raw structural edges that the parser already extracts:
+
+```text
+member/data access candidates
+control-flow markers
+```
+
+This keeps the feature on-demand and structural only.
+
+## Scope
+
+Allowed owners:
+
+```text
+src/indexer/cpp_function_graph_resolver.py
+src/indexer/cpp_function_graph_service.py
+tests/test_cpp_function_graph_resolver.py
+docs/work/
+docs/workplans/
+```
+
+No MCP tool expansion is required because `get_function_body_graph` already exposes:
+
+```text
+includeDataAccess
+includeControlFlow
+```
+
+## Non-Goals
+
+```text
+No Tree-sitter dependency change.
+No vector sidecar.
+No behavior claims.
+No data-flow analysis.
+No full CFG.
+No compiler-level aliasing or write/read certainty.
+No new MCP tools.
+```
+
+## Implementation Steps
+
+### Step 1: Data and Control-Flow Edges
+
+Status: complete.
+
+Actions:
+
+```text
+Emit reads_data_candidate and writes_data_candidate edges from raw member accesses.
+Emit control_flow_marker edges from raw control-flow markers.
+Respect includeDataAccess and includeControlFlow request flags.
+Keep claimStrength=source_structure_allowed and behaviorClaimsAllowed=false.
+Separate graph cache entries by relevant graph options.
+```
+
+Observable result:
+
+```text
+Unit tests prove data/control-flow edges are emitted and can be disabled.
+```
+
+## Acceptance Criteria
+
+```text
+Function graph remains on-demand.
+Normal indexing remains unchanged.
+Existing MCP tool schema remains stable.
+Data and control-flow edges are structural only.
+Cache hits do not cross incompatible include flag combinations.
+```

--- a/docs/workplans/completed/on-demand-cpp-function-body-relation-graph.md
+++ b/docs/workplans/completed/on-demand-cpp-function-body-relation-graph.md
@@ -1,0 +1,1404 @@
+# Workplan: On-Demand C++ Function Body Relation Graph
+
+Date: 2026-06-17
+Status: completed
+Implementation language: Python
+Component: C++ MCP Project Indexer
+Priority: medium/high
+
+## Goal
+
+Add an on-demand function-body graph layer to the existing Python C++ indexer.
+
+The existing indexer already owns the base project knowledge:
+
+```text
+files
+module graph/tree
+module imports/exports
+namespace/class/function/type symbols
+declaration/definition ranges
+symbol ids
+file/index fingerprints
+```
+
+The new feature adds lazy function-body analysis:
+
+```text
+function symbol id
+-> extract complete function text including body
+-> parse with Tree-sitter or another AST parser
+-> extract syntactic relations
+-> resolve names against the existing index
+-> cache graph edges with fingerprints
+```
+
+The graph is a navigation/evidence-routing structure, not a full C++ compiler.
+
+## Core Principle
+
+```text
+Tree-sitter extracts syntax.
+The existing indexer resolves project visibility.
+The function graph stores candidate/resolved edges.
+Source reads prove behavior.
+External APIs stay external.
+```
+
+## Non-Goals
+
+This work must not attempt to build a complete C++ semantic compiler.
+
+Out of scope:
+
+```text
+full overload resolution
+full template instantiation
+ADL correctness
+macro expansion semantics
+external API resolution
+standard library resolution
+Win32/WIL/ATL/STL semantic modeling
+compile_commands-dependent correctness
+```
+
+External APIs are not resolved. They are marked as external or unresolved.
+
+## Runtime Model
+
+The feature is on-demand.
+
+Normal indexing remains fast and unchanged:
+
+```text
+normal index run
+  -> file/module/symbol/range/fingerprint index
+```
+
+Function graph analysis runs only when requested:
+
+```text
+get_function_body_graph(symbolId, mode=compute_if_missing)
+  -> extract function text
+  -> parse AST
+  -> resolve project-local candidates
+  -> cache result
+  -> return graph
+```
+
+Optional future background warmup may precompute frequently used functions, but the first implementation must not block the base index.
+
+## Current Implementation State
+
+```text
+Step 0 preflight is documented in docs/work/P00-function-graph-preflight.md.
+Step 1 function source extraction is documented in docs/work/P01-function-source-extraction.md.
+Step 2 data contracts and empty graph result are documented in docs/work/P02-data-contracts-empty-graph.md.
+Step 3 parser adapter and raw extraction are documented in docs/work/P03-parser-adapter-raw-extraction.md.
+Step 4 visibility context is documented in docs/work/P04-visibility-context.md.
+Step 5 project-only resolver is documented in docs/work/P05-project-only-resolver.md.
+Step 6 cache and SQLite storage is documented in docs/work/P06-cache-sqlite-storage.md.
+Step 7 MCP tool get_function_body_graph is documented in docs/work/P07-mcp-get-function-body-graph.md.
+Step 8 xrefs and neighborhood tools are documented in docs/work/P08-xrefs-neighborhood.md.
+Step 9 resolution improvements are documented in docs/work/P09-resolution-improvements.md.
+Step 10 optional vector sidecar deferral is documented in docs/work/P10-optional-vector-sidecar-deferred.md.
+No parser dependency has been added yet.
+The first MCP function graph tool and persisted xref/neighborhood tools have been registered.
+The optional vector sidecar remains future work only and was not implemented.
+```
+
+## Proposed MCP Tools
+
+### get_function_body_graph
+
+Purpose:
+
+```text
+Return direct function-body relation candidates for one function.
+```
+
+Input:
+
+```json
+{
+  "symbolId": "s_f_...",
+  "mode": "cache_only | compute_if_missing | refresh",
+  "includeControlFlow": true,
+  "includeDataAccess": true,
+  "includeExternal": true,
+  "maxEdges": 200
+}
+```
+
+Output:
+
+```json
+{
+  "schema": "cpp.function_body_graph.v0.1",
+  "status": "computed",
+  "fromCache": false,
+  "symbolId": "s_f_...",
+  "functionName": "NavigationBandProgress::Paint",
+  "parser": "tree-sitter-cpp",
+  "claimStrength": "source_structure_allowed",
+  "behaviorClaimsAllowed": false,
+  "graphFingerprint": "abc123",
+  "sourceFingerprint": "def456",
+  "edges": []
+}
+```
+
+### get_call_xrefs_from
+
+Purpose:
+
+```text
+Return callees / outgoing call edges for a function.
+```
+
+Direction:
+
+```text
+caller -> callee
+```
+
+### get_call_xrefs_to
+
+Purpose:
+
+```text
+Return callers / incoming call edges for a function.
+```
+
+Direction:
+
+```text
+callee <- caller
+```
+
+### get_symbol_neighborhood
+
+Purpose:
+
+```text
+Return callers + target + callees in one compact neighborhood.
+```
+
+Useful for Relay planning before deciding which source ranges to read.
+
+Tool ownership for all function graph tools:
+
+```text
+MCP schema/registration: src/server/code_index_mcp_server.py
+Runtime implementation: src/indexer/cpp_function_graph_service.py
+Parser/resolver/cache: src/indexer/cpp_function_graph_*.py
+Storage lookup: src/indexer/cpp_function_graph_storage.py
+```
+
+## Claim Strength
+
+Function graph results are structural evidence only.
+
+```text
+function body graph       -> source_structure_allowed
+read_symbol/read_range    -> source_behavior_allowed
+vector/semantic hit       -> routing_hint_only
+module export/import data -> metadata_only
+```
+
+The function graph may say:
+
+```text
+Paint probably calls _CalculatePulseOpacity.
+```
+
+It must not support behavior claims such as:
+
+```text
+_CalculatePulseOpacity computes animation opacity.
+```
+
+Behavior claims require source-read evidence.
+
+## Project Layout Fit
+
+The current repository source tree is:
+
+```text
+src/
+  indexer/  C++ index build, update, scanner, SQLite, watcher, export, and source/range lookup
+  server/   MCP stdio/HTTP server, management API, tool listing, and tool dispatch
+  ui/       Textual TUI, terminal control center, and legacy menu UI
+```
+
+Root-level Python files are thin backward-compatible wrappers and must not own new function graph logic.
+
+## Python Module Layout
+
+Attach production code to the existing `src/indexer` owner. Keep the MCP transport and tool registration in the existing `src/server` owner.
+
+Proposed files:
+
+```text
+src/indexer/
+  cpp_function_graph_model.py
+  cpp_function_graph_parser.py
+  cpp_function_graph_tree_sitter.py
+  cpp_function_graph_extract.py
+  cpp_function_graph_visibility.py
+  cpp_function_graph_resolver.py
+  cpp_function_graph_cache.py
+  cpp_function_graph_storage.py
+  cpp_function_graph_service.py
+
+src/server/
+  code_index_mcp_server.py
+
+tests/                         optional if a test tree is introduced in the phase
+  fixtures/function_graph/
+  test_cpp_function_graph_*.py
+```
+
+Do not create `src/cpp_indexer/`; it does not match this project. Do not put parser, resolver, or cache logic into `src/server/code_index_mcp_server.py`; that file should only expose MCP schema, validate tool arguments, call the indexer service, and format responses.
+
+## Existing Owner Boundaries
+
+Indexer owner:
+
+```text
+src/indexer/cpp_project_index.py
+  loaded index model and source-range tool logic
+
+src/indexer/cpp_index_sqlite.py
+  SQLite lookup index writer/reader
+
+src/indexer/cpp_file_index.py
+src/indexer/cpp_structural_scan.py
+src/indexer/cpp_module_scan.py
+  existing source, symbol, and module extraction inputs
+```
+
+Server owner:
+
+```text
+src/server/code_index_mcp_server.py
+  tool_definitions(...)
+  CodeIndexTools tool methods
+  McpServer.tool_handlers
+```
+
+The function graph service should live under `src/indexer` and be called by `CodeIndexTools`. New MCP tool definitions and handler registration belong in `src/server/code_index_mcp_server.py`.
+
+### cpp_function_graph_model.py
+
+Defines stable data contracts:
+
+```python
+@dataclass(frozen=True)
+class FunctionAstExtract:
+    symbol_id: str
+    source_fingerprint: str
+    parser_version: str
+    calls: list[CallOccurrence]
+    member_accesses: list[MemberAccessOccurrence]
+    local_declarations: list[LocalDeclaration]
+    control_flow: list[ControlFlowMarker]
+
+@dataclass(frozen=True)
+class FunctionGraphEdge:
+    from_symbol_id: str
+    edge_kind: str
+    to_text: str
+    to_symbol_id: str | None
+    resolution_status: str
+    confidence: float
+    basis: list[str]
+    claim_strength: str
+    behavior_claims_allowed: bool
+```
+
+Allowed `resolution_status` values:
+
+```text
+exact
+probable
+ambiguous
+unresolved
+external
+```
+
+Allowed edge kinds:
+
+```text
+calls_resolved
+calls_candidate
+calls_ambiguous
+calls_external
+calls_unresolved
+reads_data_candidate
+writes_data_candidate
+uses_type_candidate
+control_flow_marker
+```
+
+## On-Demand Flow
+
+```text
+1. Receive symbolId.
+2. Resolve symbolId to file path and function range from existing index.
+3. Extract complete function text including signature and body.
+4. Compute function body fingerprint.
+5. Check FunctionGraphCache.
+6. If cache miss:
+     parse function text with AST parser
+     extract raw syntactic occurrences
+     build visibility context
+     resolve occurrences against existing index
+     write graph edges
+     store cache entry
+7. Return compact graph result.
+```
+
+## Function Extraction
+
+The indexer already knows function ranges.
+
+Preferred input to parser:
+
+```text
+complete function definition including signature and body
+```
+
+Example:
+
+```cpp
+void NavigationBandProgress::Paint(...)
+{
+    auto opacity = _CalculatePulseOpacity();
+    _OverlayPosition = opacity;
+}
+```
+
+If only the body is available in a future fallback path, wrap it:
+
+```cpp
+void __mw_dummy_function__()
+{
+    // original body here
+}
+```
+
+Line and byte offsets must be mapped back to original file coordinates.
+
+## AST Parser Adapter
+
+Do not bind the rest of the indexer directly to Tree-sitter.
+
+Use an adapter interface:
+
+```python
+class FunctionBodyParser(Protocol):
+    parser_id: str
+    parser_version: str
+
+    def parse_function(
+        self,
+        function_text: str,
+        base_line: int,
+        base_byte: int,
+    ) -> FunctionAstExtract:
+        ...
+```
+
+Initial implementation:
+
+```text
+Tree-sitter C++ adapter
+```
+
+Future optional implementations:
+
+```text
+Clang/clangd semantic adapter
+custom lightweight parser
+test fixture parser
+```
+
+## Raw AST Extraction
+
+The AST extractor should initially extract only cheap, stable syntax facts.
+
+### Calls
+
+Extract:
+
+```text
+callee text
+qualified/unqualified/member call kind
+argument count
+line/column/range
+```
+
+Examples:
+
+```cpp
+foo()
+NS::foo()
+object.foo()
+this->foo()
+```
+
+### Member/Data Accesses
+
+Extract:
+
+```text
+identifier/member text
+read/write candidate
+assignment lhs/rhs
+line/range
+```
+
+Examples:
+
+```cpp
+_OverlayPosition = value;     -> write candidate
+if (_OverlayPosition > 0)     -> read candidate
+this->_State.Reset();         -> member call or member access
+```
+
+### Local Declarations
+
+Extract:
+
+```text
+local name
+type text when visible
+line/range
+```
+
+Examples:
+
+```cpp
+RECT rc;
+auto opacity = ...;
+NavigationBandProgress* p = ...;
+```
+
+### Control-Flow Markers
+
+Extract compact markers only:
+
+```text
+if
+switch
+for
+while
+return
+throw
+try
+catch
+co_await
+co_return
+```
+
+Control-flow markers are not a full CFG in v0.1.
+
+## Visibility Context
+
+Before resolving names, build a function-local visibility context from existing index data.
+
+Input:
+
+```text
+function symbol
+file
+module imports
+module exports visible to file
+namespace stack
+class/type stack
+base classes if indexed
+same-file symbols
+anonymous namespace symbols
+static/file-local symbols
+using declarations
+using namespace directives
+namespace aliases
+local declarations from AST
+```
+
+Suggested structure:
+
+```python
+@dataclass
+class FunctionVisibilityContext:
+    file_id: str
+    file_path: str
+    function_symbol_id: str
+    current_namespace: list[str]
+    current_class_symbol_id: str | None
+    imported_modules: list[str]
+    visible_exported_symbols: list[str]
+    same_file_symbols: list[str]
+    anonymous_namespace_symbols: list[str]
+    using_declarations: list[UsingDeclaration]
+    using_directives: list[UsingDirective]
+    namespace_aliases: list[NamespaceAlias]
+    local_declarations: list[LocalDeclaration]
+```
+
+## Handling using namespace
+
+`using namespace NS;` must be treated as an additional candidate namespace, not as a guaranteed match.
+
+Store:
+
+```text
+scope id
+namespace name
+activeFromLine
+activeToLine
+source file
+```
+
+Resolution rule:
+
+```text
+Unqualified lookup includes active using namespace candidates.
+If more than one candidate matches, return ambiguous.
+```
+
+Example:
+
+```cpp
+using namespace SmartFTP::Theme;
+
+void Paint()
+{
+    DrawBackground();
+}
+```
+
+Resolver checks:
+
+```text
+current class
+current namespace
+same-file symbols
+using namespace SmartFTP::Theme
+imported module exports
+```
+
+If one project-local candidate remains:
+
+```text
+resolutionStatus = probable or exact
+```
+
+If multiple candidates remain:
+
+```text
+resolutionStatus = ambiguous
+```
+
+## Name Resolution Rules
+
+### Unqualified Call
+
+For:
+
+```cpp
+foo(a, b);
+```
+
+Resolver order:
+
+```text
+1. local declarations / local callable objects
+2. current class / this scope
+3. base classes, if indexed
+4. enclosing namespace chain
+5. same-file static symbols
+6. anonymous namespace symbols
+7. using declarations
+8. using namespace candidates
+9. imported module exports visible in scope
+10. global project symbols
+11. external/unresolved
+```
+
+### Qualified Call
+
+For:
+
+```cpp
+UI::DrawText(...)
+SmartFTP::UI::DrawText(...)
+```
+
+Resolver order:
+
+```text
+1. expand namespace aliases
+2. search exact qualified name in project index
+3. search imported module exports
+4. if not found, mark external/unresolved
+```
+
+### Member Call
+
+For:
+
+```cpp
+object.foo()
+this->foo()
+foo()
+```
+
+Resolution:
+
+```text
+this->foo:
+  current class member search
+
+object.foo:
+  if object type is known from local declarations or member data, search that type
+  otherwise return member_call_candidate
+
+foo:
+  normal unqualified lookup, including class scope
+```
+
+## Overload Resolution
+
+Do not attempt complete C++ overload resolution in v0.1.
+
+Use scoring.
+
+Signals:
+
+```text
+name match
+scope match
+argument count match
+default argument compatibility when known
+member/static context
+literal argument hints
+local variable type hints when available
+```
+
+Output may be:
+
+```text
+exact
+probable
+ambiguous
+unresolved
+external
+```
+
+If multiple overloads are plausible, return all candidates with scores.
+
+Example:
+
+```json
+{
+  "resolutionStatus": "ambiguous",
+  "toText": "Draw",
+  "candidates": [
+    {
+      "symbolId": "s_f_1",
+      "qualifiedName": "SmartFTP::UI::Draw(HDC, RECT)",
+      "score": 0.72,
+      "basis": ["using_namespace", "arity_match"]
+    },
+    {
+      "symbolId": "s_f_2",
+      "qualifiedName": "SmartFTP::UI::Draw(ID2D1DeviceContext*, D2D1_RECT_F)",
+      "score": 0.68,
+      "basis": ["using_namespace", "arity_match"]
+    }
+  ]
+}
+```
+
+## External API Rule
+
+The resolver must not try to resolve external APIs.
+
+If the target is not in:
+
+```text
+project symbol index
+project module exports
+same-file symbols
+known project namespaces
+```
+
+then mark as:
+
+```text
+resolutionStatus = external
+```
+
+Example:
+
+```cpp
+SendMessageW(...)
+std::move(...)
+wil::unique_hmodule(...)
+```
+
+Output:
+
+```json
+{
+  "edgeKind": "calls_external",
+  "toText": "SendMessageW",
+  "resolutionStatus": "external",
+  "reason": "not_in_project_symbol_index",
+  "claimStrength": "source_structure_allowed",
+  "behaviorClaimsAllowed": false
+}
+```
+
+## Graph Expansion
+
+Direct graph:
+
+```text
+depth = 1
+```
+
+Only direct function-body edges.
+
+Recursive graph:
+
+```text
+depth > 1
+```
+
+May parse project-local resolved/probable callees lazily.
+
+Expansion guards:
+
+```text
+maxDepth
+maxNodes
+maxEdges
+cycle detection
+external stops
+ambiguous does not auto-expand unless explicitly requested
+```
+
+Default:
+
+```text
+depth = 1
+maxNodes = 25
+maxEdges = 200
+```
+
+## Cache Design
+
+Use two cache layers.
+
+### Function AST Extract Cache
+
+Key:
+
+```text
+functionBodyFingerprint
+parserId
+parserVersion
+extractorVersion
+```
+
+Value:
+
+```text
+raw AST-derived calls/member accesses/local declarations/control-flow markers
+```
+
+### Function Graph Resolution Cache
+
+Key:
+
+```text
+functionBodyFingerprint
+fileFingerprint
+symbolIndexFingerprint
+moduleVisibilityFingerprint
+parserId
+parserVersion
+resolverVersion
+```
+
+Value:
+
+```text
+resolved/candidate/ambiguous/external graph edges
+```
+
+Reason:
+
+```text
+Function text may stay unchanged while module exports or symbol index changes.
+In that case AST extraction remains valid but resolution must refresh.
+```
+
+## Fingerprints
+
+Each graph result should include:
+
+```text
+functionBodyFingerprint
+fileFingerprint
+symbolIndexFingerprint
+moduleVisibilityFingerprint
+parserVersion
+resolverVersion
+graphFingerprint
+```
+
+These fingerprints make cached graph results safe to reuse and explainable in Relay artifacts.
+
+## Storage
+
+Initial implementation may use SQLite tables next to the existing index database.
+
+Implement storage through the existing SQLite ownership pattern in `src/indexer/cpp_index_sqlite.py` plus a focused `src/indexer/cpp_function_graph_storage.py` helper. Do not create a separate database root or a second index lifecycle.
+
+Suggested tables:
+
+```sql
+function_ast_extract_cache(
+  function_symbol_id TEXT,
+  function_body_fingerprint TEXT,
+  parser_id TEXT,
+  parser_version TEXT,
+  extractor_version TEXT,
+  payload_json TEXT,
+  created_at TEXT,
+  PRIMARY KEY(function_symbol_id, function_body_fingerprint, parser_id, parser_version, extractor_version)
+);
+
+function_graph_cache(
+  function_symbol_id TEXT,
+  graph_fingerprint TEXT,
+  function_body_fingerprint TEXT,
+  file_fingerprint TEXT,
+  symbol_index_fingerprint TEXT,
+  module_visibility_fingerprint TEXT,
+  parser_id TEXT,
+  parser_version TEXT,
+  resolver_version TEXT,
+  payload_json TEXT,
+  created_at TEXT,
+  PRIMARY KEY(function_symbol_id, graph_fingerprint)
+);
+
+function_graph_edges(
+  graph_fingerprint TEXT,
+  from_symbol_id TEXT,
+  to_symbol_id TEXT,
+  to_text TEXT,
+  edge_kind TEXT,
+  resolution_status TEXT,
+  confidence REAL,
+  claim_strength TEXT,
+  behavior_claims_allowed INTEGER,
+  basis_json TEXT,
+  evidence_json TEXT
+);
+```
+
+## Result Example
+
+```json
+{
+  "schema": "cpp.function_body_graph.v0.1",
+  "status": "computed",
+  "fromCache": false,
+  "symbolId": "s_f_paint",
+  "functionName": "NavigationBandProgress::Paint",
+  "file": "DWrapper/Shell/AddressBand/NavigationBandProgress/NavigationBandProgress.cpp",
+  "range": {
+    "startLine": 580,
+    "endLine": 690
+  },
+  "parser": {
+    "id": "tree-sitter-cpp",
+    "version": "..."
+  },
+  "resolver": {
+    "version": "cpp-function-graph-resolver-v0.1"
+  },
+  "claimStrength": "source_structure_allowed",
+  "behaviorClaimsAllowed": false,
+  "fingerprints": {
+    "functionBody": "sha256:...",
+    "file": "sha256:...",
+    "symbolIndex": "sha256:...",
+    "moduleVisibility": "sha256:...",
+    "graph": "sha256:..."
+  },
+  "edges": [
+    {
+      "edgeKind": "calls_candidate",
+      "toText": "_CalculatePulseOpacity",
+      "toSymbolId": "s_f_calc_pulse",
+      "resolutionStatus": "probable",
+      "confidence": 0.86,
+      "basis": ["same_class", "arity_match", "same_file"],
+      "evidence": {
+        "line": 621,
+        "kind": "tree_sitter_call_expression"
+      }
+    }
+  ]
+}
+```
+
+## Relay Usage
+
+Relay may use the graph for planning:
+
+```text
+find_symbol Paint
+-> get_function_body_graph(Paint)
+-> see direct helper/data candidates
+-> read_symbol Paint
+-> read_symbol selected project-local helper
+-> read_data selected member if needed
+```
+
+Relay must not use the graph as behavior evidence.
+
+Allowed Relay claim:
+
+```text
+The graph suggests Paint has a project-local call candidate to _CalculatePulseOpacity.
+```
+
+Not allowed without source read:
+
+```text
+_CalculatePulseOpacity computes the animation opacity.
+```
+
+## Testing
+
+### Unit Tests
+
+Place tests according to the first phase that introduces a test tree. If this repository still has no test root when Phase 1 starts, create a small top-level `tests/` tree rather than hiding tests under `src/indexer`.
+
+```text
+extract_unqualified_call
+extract_qualified_call
+extract_member_call
+extract_assignment_lhs_member_write
+extract_local_declaration
+using_namespace_adds_candidate_scope
+namespace_alias_expands_qualified_name
+same_class_method_resolution
+same_file_static_resolution
+imported_module_export_resolution
+ambiguous_overload_set
+external_api_marked_external
+cache_hit_same_fingerprints
+resolution_refresh_on_module_visibility_change
+```
+
+### Fixture Files
+
+Create compact C++ fixtures for:
+
+```text
+namespace lookup
+using namespace
+using declaration
+namespace alias
+class member call
+static same-file helper
+anonymous namespace helper
+overloaded functions
+imported module export call
+external Win32/STL call
+member data read/write
+```
+
+### Smoke Test
+
+```text
+check-function-body-graph-smoke
+```
+
+Scenario:
+
+```text
+1. Load small fixture project.
+2. Find function symbol.
+3. Call get_function_body_graph(compute_if_missing).
+4. Assert expected edges.
+5. Call again with cache_only.
+6. Assert cache hit and same graphFingerprint.
+```
+
+## Implementation Steps
+
+### Step 0: Repo and Contract Preflight
+
+Status: documented.
+
+Owner:
+
+```text
+docs/work/P00-function-graph-preflight.md
+```
+
+Actions:
+
+```text
+Inspect src/indexer/README.md and src/server/README.md.
+Identify current symbol/range lookup owners in src/indexer/cpp_project_index.py.
+Identify current SQLite owner in src/indexer/cpp_index_sqlite.py.
+Identify current MCP schema and dispatch points in src/server/code_index_mcp_server.py.
+Record Tree-sitter dependency decision before parser work starts.
+```
+
+Observable result:
+
+```text
+Worklog records owners, target paths, test strategy, dependency stance, and non-goals.
+```
+
+### Step 1: Function Source Extraction
+
+Status: complete.
+
+Owner:
+
+```text
+src/indexer/cpp_function_graph_service.py
+```
+
+Actions:
+
+```text
+Resolve symbolId through the loaded index.
+Reject missing symbols and non-callable symbols with structured errors.
+Read complete indexed symbol range from the source file.
+Return function text, fileId, relativePath, start/end lines, base line/byte, and functionBodyFingerprint.
+Do not parse the function body yet.
+Do not expose an MCP tool yet.
+```
+
+Observable result:
+
+```text
+Unit test proves a function symbol maps to exact indexed text and stable fingerprint.
+```
+
+### Step 2: Data Contracts and Empty Service Shell
+
+Status: complete.
+
+Owner:
+
+```text
+src/indexer/cpp_function_graph_model.py
+src/indexer/cpp_function_graph_service.py
+```
+
+Actions:
+
+```text
+Define FunctionGraphRequest, FunctionSourceSlice, FunctionAstExtract, FunctionGraphEdge, FunctionGraphResult, and FunctionGraphFingerprints.
+Define allowed resolution statuses and edge kinds as explicit constants or Literal types.
+Return a valid empty graph result for a function source slice.
+Always emit claimStrength=source_structure_allowed and behaviorClaimsAllowed=false.
+```
+
+Observable result:
+
+```text
+Unit test proves the empty service result has schema, symbol id, source fingerprint, graph fingerprint, and zero edges.
+```
+
+### Step 3: Parser Adapter and Raw Extraction
+
+Status: complete.
+
+Owner:
+
+```text
+src/indexer/cpp_function_graph_parser.py
+src/indexer/cpp_function_graph_extract.py
+src/indexer/cpp_function_graph_tree_sitter.py
+```
+
+Actions:
+
+```text
+Define FunctionBodyParser protocol.
+Keep Tree-sitter isolated behind the parser adapter.
+Add a test fixture parser if Tree-sitter is not yet available in the repo dependencies.
+Extract raw calls, member/data access candidates, local declarations, and compact control-flow markers.
+Map parser locations back to original file lines.
+```
+
+Observable result:
+
+```text
+Unit tests prove raw extraction for unqualified call, qualified call, member call, assignment lhs member write, local declaration, and control-flow marker.
+```
+
+### Step 4: Visibility Context
+
+Status: complete.
+
+Owner:
+
+```text
+src/indexer/cpp_function_graph_visibility.py
+```
+
+Actions:
+
+```text
+Build FunctionVisibilityContext from existing symbol, file, module, and data indexes.
+Include current namespace/class, same-file symbols, imported modules, visible exports, and indexed member data when available.
+Keep using namespace/declaration and namespace alias support as recorded candidates, not guaranteed matches.
+```
+
+Observable result:
+
+```text
+Unit test proves the visibility context for a fixture function includes same-file callable symbols and current class context.
+```
+
+### Step 5: Project-Only Resolver v0.1
+
+Status: complete.
+
+Owner:
+
+```text
+src/indexer/cpp_function_graph_resolver.py
+```
+
+Actions:
+
+```text
+Resolve unqualified calls against current class, same-file symbols, namespace chain, and project symbols.
+Resolve qualified calls by exact qualified name and imported module exports.
+Resolve this->member calls against current class when indexed.
+Return ambiguous candidate sets instead of choosing fake certainty.
+Mark non-project targets external or unresolved.
+Never model Win32, STL, WIL, ATL, ADL, templates, or full overload semantics.
+```
+
+Observable result:
+
+```text
+Unit tests prove same-class method resolution, same-file static resolution, ambiguous overload output, and external API marking.
+```
+
+### Step 6: Cache and SQLite Storage
+
+Status: complete.
+
+Owner:
+
+```text
+src/indexer/cpp_function_graph_cache.py
+src/indexer/cpp_function_graph_storage.py
+src/indexer/cpp_index_sqlite.py
+```
+
+Actions:
+
+```text
+Add AST extract cache keyed by functionBodyFingerprint, parser id/version, and extractor version.
+Add graph resolution cache keyed by function body, file, symbol index, module visibility, parser, and resolver fingerprints.
+Store graph edges next to the existing index database.
+Do not create a separate database root or second index lifecycle.
+```
+
+Observable result:
+
+```text
+Smoke test proves compute_if_missing stores a graph and cache_only returns the same graphFingerprint.
+```
+
+### Step 7: MCP Tool get_function_body_graph
+
+Status: complete.
+
+Owner:
+
+```text
+src/server/code_index_mcp_server.py
+```
+
+Actions:
+
+```text
+Register get_function_body_graph in tool_definitions.
+Add a CodeIndexTools method that validates arguments and calls the indexer service.
+Add handler registration in McpServer.tool_handlers.
+Keep output compact and packable.
+Return schema, status, fromCache, symbolId, functionName, parser/resolver metadata, fingerprints, edges, claimStrength, and behaviorClaimsAllowed.
+```
+
+Observable result:
+
+```text
+MCP smoke test proves get_function_body_graph(compute_if_missing) returns structural graph data without behavior claims.
+```
+
+### Step 8: Xrefs and Neighborhood
+
+Status: complete.
+
+Owner:
+
+```text
+src/indexer/cpp_function_graph_storage.py
+src/indexer/cpp_function_graph_service.py
+src/server/code_index_mcp_server.py
+```
+
+Actions:
+
+```text
+Expose get_call_xrefs_from only after edges are persisted.
+Expose get_call_xrefs_to only after incoming edge lookup exists.
+Expose get_symbol_neighborhood as target plus compact caller/callee sets.
+Keep all three tools structural and compact.
+```
+
+Observable result:
+
+```text
+Smoke test proves persisted edges can be queried in both directions and as a neighborhood.
+```
+
+### Step 9: Resolution Improvements
+
+Status: complete.
+
+Owner:
+
+```text
+src/indexer/cpp_function_graph_visibility.py
+src/indexer/cpp_function_graph_resolver.py
+```
+
+Actions:
+
+```text
+Improve using namespace and using declaration candidate handling.
+Add namespace alias expansion.
+Improve overload scoring with arity, scope, member/static context, and local type hints.
+Keep ambiguous results explicit.
+```
+
+Observable result:
+
+```text
+Unit tests prove using namespace ambiguity, namespace alias qualified lookup, and overload scoring without fake exact matches.
+```
+
+### Step 10: Optional Vector Sidecar
+
+Status: deferred future work.
+
+Owner:
+
+```text
+future work only
+```
+
+Actions:
+
+```text
+Do not implement until function graph storage and MCP behavior are stable.
+If added later, vectors are routing_hint_only and never behavior evidence.
+```
+
+Observable result:
+
+```text
+No implementation in the initial workplan.
+```
+
+## Acceptance Criteria
+
+```text
+Base indexing remains unchanged and fast.
+Function graph analysis is on-demand.
+Tree-sitter or AST parser is isolated behind a Python adapter.
+Complete function text including body is extracted from existing ranges.
+Project-local calls resolve to symbol IDs when possible.
+External calls stay external/unresolved.
+Ambiguous overloads return candidate sets, not fake certainty.
+Graph results are fingerprint-backed and cacheable.
+MCP output declares source_structure_allowed and behaviorClaimsAllowed=false.
+Relay can use graph results for planning but not behavior claims.
+Smoke tests prove compute + cache + xrefs behavior.
+```
+
+## Workplan Discipline
+
+Before implementing any phase:
+
+```text
+1. Read this workplan.
+2. Inspect current index ownership for symbols, file ranges, module visibility, storage, and MCP tools.
+3. Report the exact phase being implemented.
+4. Report expected touched files before coding.
+5. Stop if the phase would require unrelated provider behavior, a second indexer loop, or a broad helper library.
+```
+
+After implementing a phase:
+
+```text
+1. Add or update a docs/work/Pxx-*.md work log.
+2. Record changed files, owner/module, runtime path, tests, cache/artifact evidence, non-goals, and follow-ups.
+3. Update docs/work/README.md if a new work log file is added.
+4. Keep this workplan active until all phases are complete and verified.
+```
+
+## Final Report Format
+
+When implemented, report:
+
+```text
+Summary:
+  What was added.
+
+Parser:
+  Which AST parser adapter is active.
+
+Index integration:
+  Which existing index data is used.
+
+Resolution:
+  Which name-resolution cases work.
+
+Cache:
+  Which fingerprints protect reuse.
+
+MCP tools:
+  Which tools were added.
+
+Tests:
+  Unit and smoke tests run.
+
+Non-goals respected:
+  No full C++ compiler semantics.
+  No external API resolution.
+  No behavior claims from graph data.
+```

--- a/src/indexer/cpp_function_graph_cache.py
+++ b/src/indexer/cpp_function_graph_cache.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import hashlib
+import json
+
+from dataclasses import dataclass
+from typing import Any
+
+from cpp_function_graph_model import FunctionAstExtract, FunctionGraphResult
+
+
+@dataclass(frozen=True, slots=True)
+class FunctionAstCacheKey:
+    function_symbol_id: str
+    function_body_fingerprint: str
+    parser_id: str
+    parser_version: str
+    extractor_version: str
+
+
+@dataclass(frozen=True, slots=True)
+class FunctionGraphCacheKey:
+    function_symbol_id: str
+    function_body_fingerprint: str
+    file_fingerprint: str
+    symbol_index_fingerprint: str
+    module_visibility_fingerprint: str
+    parser_id: str
+    parser_version: str
+    resolver_version: str
+
+
+def stable_json_fingerprint(payload: Any) -> str:
+    text = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def ast_cache_key_for_extract(extract: FunctionAstExtract) -> FunctionAstCacheKey:
+    return FunctionAstCacheKey(
+        function_symbol_id=extract.symbol_id,
+        function_body_fingerprint=extract.source_fingerprint,
+        parser_id=extract.parser_id,
+        parser_version=extract.parser_version,
+        extractor_version=extract.extractor_version,
+    )
+
+
+def graph_cache_key_for_result(
+    result: FunctionGraphResult,
+    *,
+    file_fingerprint: str,
+    symbol_index_fingerprint: str,
+    module_visibility_fingerprint: str,
+) -> FunctionGraphCacheKey:
+    return FunctionGraphCacheKey(
+        function_symbol_id=result.symbol_id,
+        function_body_fingerprint=result.fingerprints.function_body,
+        file_fingerprint=file_fingerprint,
+        symbol_index_fingerprint=symbol_index_fingerprint,
+        module_visibility_fingerprint=module_visibility_fingerprint,
+        parser_id=result.parser_id or "",
+        parser_version=result.parser_version or "",
+        resolver_version=result.resolver_version or "",
+    )

--- a/src/indexer/cpp_function_graph_extract.py
+++ b/src/indexer/cpp_function_graph_extract.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import re
+
+from cpp_function_graph_model import FunctionAstExtract
+
+
+EXTRACTOR_VERSION = "cpp-function-graph-raw-extractor-v0.1"
+LIGHTWEIGHT_PARSER_ID = "cpp-lightweight-function-parser"
+LIGHTWEIGHT_PARSER_VERSION = "v0.1"
+
+CONTROL_FLOW_WORDS = {
+    "if",
+    "switch",
+    "for",
+    "while",
+    "return",
+    "throw",
+    "try",
+    "catch",
+    "co_await",
+    "co_return",
+}
+
+CALL_EXCLUDE_WORDS = CONTROL_FLOW_WORDS | {
+    "sizeof",
+    "alignof",
+    "decltype",
+    "static_cast",
+    "reinterpret_cast",
+    "const_cast",
+    "dynamic_cast",
+}
+
+CALL_RE = re.compile(
+    r"(?P<callee>\b[A-Za-z_]\w*(?:(?:::|->|\.)[A-Za-z_]\w*)*)\s*\(",
+)
+CONTROL_RE = re.compile(r"\b(if|switch|for|while|return|throw|try|catch|co_await|co_return)\b")
+LOCAL_DECL_RE = re.compile(
+    r"^\s*(?P<type>(?:const\s+)?(?:auto|[A-Za-z_]\w*(?:::[A-Za-z_]\w*)?)(?:\s*[*&])?)\s+"
+    r"(?P<name>[A-Za-z_]\w*)\s*(?:[=;({])"
+)
+MEMBER_TOKEN_RE = re.compile(r"\b(?P<member>this->\w+|[A-Za-z_]\w*\.\w+|_\w+)\b")
+ASSIGNMENT_RE = re.compile(r"(?P<lhs>this->\w+|[A-Za-z_]\w*\.\w+|_\w+)\s*=")
+
+
+def extract_raw_function_ast(
+    *,
+    symbol_id: str,
+    source_fingerprint: str,
+    function_text: str,
+    base_line: int,
+    base_byte: int,
+    parser_id: str = LIGHTWEIGHT_PARSER_ID,
+    parser_version: str = LIGHTWEIGHT_PARSER_VERSION,
+) -> FunctionAstExtract:
+    calls: list[dict] = []
+    member_accesses: list[dict] = []
+    local_declarations: list[dict] = []
+    control_flow: list[dict] = []
+
+    byte_cursor = base_byte
+    in_body = False
+    for offset, line in enumerate(function_text.splitlines(keepends=True)):
+        line_number = base_line + offset
+        line_text = line.rstrip("\r\n")
+
+        if in_body:
+            calls.extend(_extract_calls(line_text, line_number=line_number, byte_cursor=byte_cursor))
+            member_accesses.extend(_extract_member_accesses(line_text, line_number=line_number, byte_cursor=byte_cursor))
+            local_declarations.extend(_extract_local_declarations(line_text, line_number=line_number, byte_cursor=byte_cursor))
+            control_flow.extend(_extract_control_flow(line_text, line_number=line_number, byte_cursor=byte_cursor))
+
+        if "{" in line_text:
+            in_body = True
+
+        byte_cursor += len(line.encode("utf-8"))
+
+    return FunctionAstExtract(
+        symbol_id=symbol_id,
+        source_fingerprint=source_fingerprint,
+        parser_id=parser_id,
+        parser_version=parser_version,
+        extractor_version=EXTRACTOR_VERSION,
+        calls=tuple(calls),
+        member_accesses=tuple(member_accesses),
+        local_declarations=tuple(local_declarations),
+        control_flow=tuple(control_flow),
+    )
+
+
+def _extract_calls(line: str, *, line_number: int, byte_cursor: int) -> list[dict]:
+    result: list[dict] = []
+    for match in CALL_RE.finditer(_strip_line_comment(line)):
+        callee = match.group("callee")
+        tail = callee.rsplit("::", 1)[-1].rsplit("->", 1)[-1].rsplit(".", 1)[-1]
+        if tail in CALL_EXCLUDE_WORDS:
+            continue
+
+        result.append(
+            {
+                "callee": callee,
+                "callKind": _call_kind(callee),
+                "argumentCount": _argument_count(line, match.end() - 1),
+                "line": line_number,
+                "column": match.start("callee"),
+                "byte": byte_cursor + len(line[:match.start("callee")].encode("utf-8")),
+                "kind": "call_expression",
+            }
+        )
+
+    return result
+
+
+def _extract_member_accesses(line: str, *, line_number: int, byte_cursor: int) -> list[dict]:
+    stripped = _strip_line_comment(line)
+    writes = {
+        match.group("lhs"): match
+        for match in ASSIGNMENT_RE.finditer(stripped)
+    }
+    result: list[dict] = []
+    seen: set[tuple[str, int]] = set()
+
+    for match in MEMBER_TOKEN_RE.finditer(stripped):
+        text = match.group("member")
+        key = (text, match.start("member"))
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(
+            {
+                "text": text,
+                "accessKind": "write_candidate" if text in writes else "read_candidate",
+                "line": line_number,
+                "column": match.start("member"),
+                "byte": byte_cursor + len(line[:match.start("member")].encode("utf-8")),
+                "kind": "member_access",
+            }
+        )
+
+    return result
+
+
+def _extract_local_declarations(line: str, *, line_number: int, byte_cursor: int) -> list[dict]:
+    stripped = _strip_line_comment(line)
+    match = LOCAL_DECL_RE.match(stripped)
+    if match is None:
+        return []
+
+    type_text = match.group("type").strip()
+    if type_text in CONTROL_FLOW_WORDS:
+        return []
+
+    name = match.group("name")
+    name_column = stripped.find(name)
+    return [
+        {
+            "name": name,
+            "typeText": type_text,
+            "line": line_number,
+            "column": name_column,
+            "byte": byte_cursor + len(line[:name_column].encode("utf-8")),
+            "kind": "local_declaration",
+        }
+    ]
+
+
+def _extract_control_flow(line: str, *, line_number: int, byte_cursor: int) -> list[dict]:
+    result: list[dict] = []
+    for match in CONTROL_RE.finditer(_strip_line_comment(line)):
+        result.append(
+            {
+                "marker": match.group(1),
+                "line": line_number,
+                "column": match.start(1),
+                "byte": byte_cursor + len(line[:match.start(1)].encode("utf-8")),
+                "kind": "control_flow_marker",
+            }
+        )
+    return result
+
+
+def _call_kind(callee: str) -> str:
+    if "->" in callee or "." in callee:
+        return "member"
+    if "::" in callee:
+        return "qualified"
+    return "unqualified"
+
+
+def _argument_count(line: str, open_paren_index: int) -> int:
+    close_index = _find_close_paren(line, open_paren_index)
+    if close_index is None:
+        return 0
+
+    text = line[open_paren_index + 1:close_index].strip()
+    if not text:
+        return 0
+
+    depth = 0
+    count = 1
+    for char in text:
+        if char in "([{":
+            depth += 1
+        elif char in ")]}" and depth > 0:
+            depth -= 1
+        elif char == "," and depth == 0:
+            count += 1
+    return count
+
+
+def _find_close_paren(line: str, open_paren_index: int) -> int | None:
+    depth = 0
+    for index in range(open_paren_index, len(line)):
+        char = line[index]
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                return index
+    return None
+
+
+def _strip_line_comment(line: str) -> str:
+    index = line.find("//")
+    return line if index < 0 else line[:index]
+
+
+class LightweightFunctionBodyParser:
+    parser_id = LIGHTWEIGHT_PARSER_ID
+    parser_version = LIGHTWEIGHT_PARSER_VERSION
+
+    def parse_function(
+        self,
+        *,
+        symbol_id: str,
+        source_fingerprint: str,
+        function_text: str,
+        base_line: int,
+        base_byte: int,
+    ) -> FunctionAstExtract:
+        return extract_raw_function_ast(
+            symbol_id=symbol_id,
+            source_fingerprint=source_fingerprint,
+            function_text=function_text,
+            base_line=base_line,
+            base_byte=base_byte,
+            parser_id=self.parser_id,
+            parser_version=self.parser_version,
+        )

--- a/src/indexer/cpp_function_graph_model.py
+++ b/src/indexer/cpp_function_graph_model.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+FUNCTION_GRAPH_SCHEMA = "cpp.function_body_graph.v0.1"
+SOURCE_STRUCTURE_CLAIM_STRENGTH = "source_structure_allowed"
+BEHAVIOR_CLAIMS_ALLOWED = False
+
+FunctionGraphMode = Literal["cache_only", "compute_if_missing", "refresh"]
+ResolutionStatus = Literal["exact", "probable", "ambiguous", "unresolved", "external"]
+FunctionGraphEdgeKind = Literal[
+    "calls_resolved",
+    "calls_candidate",
+    "calls_ambiguous",
+    "calls_external",
+    "calls_unresolved",
+    "reads_data_candidate",
+    "writes_data_candidate",
+    "uses_type_candidate",
+    "control_flow_marker",
+]
+
+RESOLUTION_STATUSES: tuple[str, ...] = ("exact", "probable", "ambiguous", "unresolved", "external")
+FUNCTION_GRAPH_EDGE_KINDS: tuple[str, ...] = (
+    "calls_resolved",
+    "calls_candidate",
+    "calls_ambiguous",
+    "calls_external",
+    "calls_unresolved",
+    "reads_data_candidate",
+    "writes_data_candidate",
+    "uses_type_candidate",
+    "control_flow_marker",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class FunctionGraphRequest:
+    symbol_id: str
+    mode: FunctionGraphMode = "compute_if_missing"
+    include_control_flow: bool = True
+    include_data_access: bool = True
+    include_external: bool = True
+    max_edges: int = 200
+
+
+@dataclass(frozen=True, slots=True)
+class FunctionSourceSlice:
+    symbol_id: str
+    function_name: str | None
+    qualified_name: str | None
+    symbol_type: str
+    file_id: str
+    relative_path: str
+    start_line: int
+    end_line: int
+    base_line: int
+    base_byte: int
+    text: str
+    function_body_fingerprint: str
+
+
+@dataclass(frozen=True, slots=True)
+class FunctionAstExtract:
+    symbol_id: str
+    source_fingerprint: str
+    parser_id: str
+    parser_version: str
+    extractor_version: str
+    calls: tuple[dict, ...] = ()
+    member_accesses: tuple[dict, ...] = ()
+    local_declarations: tuple[dict, ...] = ()
+    control_flow: tuple[dict, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class FunctionVisibilityContext:
+    file_id: str
+    file_path: str
+    function_symbol_id: str
+    current_namespace: tuple[str, ...]
+    current_class_symbol_id: str | None
+    current_class_name: str | None
+    imported_modules: tuple[str, ...]
+    visible_exported_symbols: tuple[dict, ...]
+    same_file_symbols: tuple[dict, ...]
+    same_file_data: tuple[dict, ...]
+    member_data: tuple[dict, ...]
+    using_declarations: tuple[dict, ...] = ()
+    using_directives: tuple[dict, ...] = ()
+    namespace_aliases: tuple[dict, ...] = ()
+    local_declarations: tuple[dict, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class FunctionGraphEdge:
+    from_symbol_id: str
+    edge_kind: FunctionGraphEdgeKind
+    to_text: str
+    to_symbol_id: str | None
+    resolution_status: ResolutionStatus
+    confidence: float
+    basis: tuple[str, ...]
+    candidates: tuple[dict, ...] = ()
+    claim_strength: str = SOURCE_STRUCTURE_CLAIM_STRENGTH
+    behavior_claims_allowed: bool = BEHAVIOR_CLAIMS_ALLOWED
+
+
+@dataclass(frozen=True, slots=True)
+class FunctionGraphFingerprints:
+    function_body: str
+    graph: str
+    file: str | None = None
+    symbol_index: str | None = None
+    module_visibility: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class FunctionGraphResult:
+    schema: str
+    status: str
+    from_cache: bool
+    symbol_id: str
+    function_name: str | None
+    qualified_name: str | None
+    file: str
+    start_line: int
+    end_line: int
+    parser_id: str | None
+    parser_version: str | None
+    resolver_version: str | None
+    claim_strength: str
+    behavior_claims_allowed: bool
+    fingerprints: FunctionGraphFingerprints
+    edges: tuple[FunctionGraphEdge, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class FunctionGraphError:
+    code: str
+    message: str
+    symbol_id: str | None = None

--- a/src/indexer/cpp_function_graph_parser.py
+++ b/src/indexer/cpp_function_graph_parser.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from cpp_function_graph_model import FunctionAstExtract
+
+
+class FunctionBodyParser(Protocol):
+    parser_id: str
+    parser_version: str
+
+    def parse_function(
+        self,
+        *,
+        symbol_id: str,
+        source_fingerprint: str,
+        function_text: str,
+        base_line: int,
+        base_byte: int,
+    ) -> FunctionAstExtract:
+        ...

--- a/src/indexer/cpp_function_graph_resolver.py
+++ b/src/indexer/cpp_function_graph_resolver.py
@@ -1,0 +1,420 @@
+from __future__ import annotations
+
+from typing import Any
+
+from cpp_function_graph_model import (
+    BEHAVIOR_CLAIMS_ALLOWED,
+    SOURCE_STRUCTURE_CLAIM_STRENGTH,
+    FunctionAstExtract,
+    FunctionGraphEdge,
+    FunctionVisibilityContext,
+)
+
+
+RESOLVER_VERSION = "cpp-function-graph-resolver-v0.1"
+EXTERNAL_QUALIFIER_PREFIXES = ("std::", "wil::", "ATL::", "Microsoft::WRL::")
+
+
+def resolve_function_graph_edges(
+    *,
+    ast_extract: FunctionAstExtract,
+    visibility: FunctionVisibilityContext,
+    include_external: bool = True,
+    max_edges: int = 200,
+) -> tuple[FunctionGraphEdge, ...]:
+    edges: list[FunctionGraphEdge] = []
+    for call in ast_extract.calls:
+        edge = resolve_call(call, visibility=visibility, include_external=include_external)
+        if edge is None:
+            continue
+        edges.append(edge)
+        if len(edges) >= max_edges:
+            break
+    return tuple(edges)
+
+
+def resolve_call(
+    call: dict[str, Any],
+    *,
+    visibility: FunctionVisibilityContext,
+    include_external: bool = True,
+) -> FunctionGraphEdge | None:
+    callee = str(call.get("callee") or "")
+    call_kind = str(call.get("callKind") or _call_kind(callee))
+    if not callee:
+        return None
+
+    if call_kind == "qualified":
+        candidates = _qualified_candidates(callee, visibility)
+        basis = ("qualified_name",)
+    elif callee.startswith("this->"):
+        candidates = _this_member_candidates(callee, visibility)
+        basis = ("this_scope", "current_class")
+    elif call_kind == "member":
+        candidates = _typed_member_candidates(callee, call, visibility)
+        basis = ("member_call_without_object_type",)
+    else:
+        candidates = _unqualified_candidates(callee, visibility)
+        basis = ("unqualified_lookup",)
+
+    if len(candidates) == 1:
+        candidate = candidates[0]
+        status = "exact" if call_kind == "qualified" or callee.startswith("this->") else "probable"
+        return FunctionGraphEdge(
+            from_symbol_id=visibility.function_symbol_id,
+            edge_kind="calls_resolved" if status == "exact" else "calls_candidate",
+            to_text=callee,
+            to_symbol_id=str(candidate.get("symbolId") or ""),
+            resolution_status=status,
+            confidence=0.95 if status == "exact" else 0.82,
+            basis=tuple(_candidate_basis(candidate, basis)),
+            candidates=(_candidate_ref(candidate),),
+            claim_strength=SOURCE_STRUCTURE_CLAIM_STRENGTH,
+            behavior_claims_allowed=BEHAVIOR_CLAIMS_ALLOWED,
+        )
+
+    if len(candidates) > 1:
+        return FunctionGraphEdge(
+            from_symbol_id=visibility.function_symbol_id,
+            edge_kind="calls_ambiguous",
+            to_text=callee,
+            to_symbol_id=None,
+            resolution_status="ambiguous",
+            confidence=max(float(candidate.get("_score") or 0.5) for candidate in candidates),
+            basis=tuple(_merge_basis(candidates, basis)),
+            candidates=tuple(_candidate_ref(candidate) for candidate in _score_candidates(candidates, call)),
+            claim_strength=SOURCE_STRUCTURE_CLAIM_STRENGTH,
+            behavior_claims_allowed=BEHAVIOR_CLAIMS_ALLOWED,
+        )
+
+    if call_kind == "member":
+        return FunctionGraphEdge(
+            from_symbol_id=visibility.function_symbol_id,
+            edge_kind="calls_unresolved",
+            to_text=callee,
+            to_symbol_id=None,
+            resolution_status="unresolved",
+            confidence=0.0,
+            basis=basis,
+            claim_strength=SOURCE_STRUCTURE_CLAIM_STRENGTH,
+            behavior_claims_allowed=BEHAVIOR_CLAIMS_ALLOWED,
+        )
+
+    if not include_external:
+        return None
+
+    return FunctionGraphEdge(
+        from_symbol_id=visibility.function_symbol_id,
+        edge_kind="calls_external",
+        to_text=callee,
+        to_symbol_id=None,
+        resolution_status="external",
+        confidence=0.0,
+        basis=("not_in_project_symbol_index",),
+        claim_strength=SOURCE_STRUCTURE_CLAIM_STRENGTH,
+        behavior_claims_allowed=BEHAVIOR_CLAIMS_ALLOWED,
+    )
+
+
+def _qualified_candidates(callee: str, visibility: FunctionVisibilityContext) -> tuple[dict[str, Any], ...]:
+    expanded = _expand_namespace_alias(callee, visibility)
+    return _dedupe_candidates(
+        _with_basis(symbol, ("qualified_name", "namespace_alias" if expanded != callee else ""))
+        for symbol in _all_project_symbols(visibility)
+        if str(symbol.get("qualifiedName") or "") == expanded
+    )
+
+
+def _this_member_candidates(callee: str, visibility: FunctionVisibilityContext) -> tuple[dict[str, Any], ...]:
+    member_name = callee.rsplit("->", 1)[-1].rsplit(".", 1)[-1]
+    return _dedupe_candidates(
+        _with_basis(symbol, ("this_scope", "current_class"))
+        for symbol in visibility.same_file_symbols
+        if _short_name(symbol) == member_name
+        and _same_container(symbol, visibility.current_class_name)
+    )
+
+
+def _typed_member_candidates(
+    callee: str,
+    call: dict[str, Any],
+    visibility: FunctionVisibilityContext,
+) -> tuple[dict[str, Any], ...]:
+    if "->" in callee:
+        object_name, member_name = callee.split("->", 1)
+    elif "." in callee:
+        object_name, member_name = callee.split(".", 1)
+    else:
+        return ()
+
+    type_name = _local_type_for_object(object_name, visibility)
+    if not type_name:
+        return ()
+
+    candidates = []
+    for symbol in _all_project_symbols(visibility):
+        if _short_name(symbol) != member_name:
+            continue
+        if _same_container(symbol, type_name):
+            candidates.append(_with_basis(symbol, ("local_type_hint", "member_call")))
+    return _dedupe_candidates(_score_candidates(candidates, call))
+
+
+def _unqualified_candidates(callee: str, visibility: FunctionVisibilityContext) -> tuple[dict[str, Any], ...]:
+    tail = _callee_tail(callee)
+    same_scope_candidates: list[dict[str, Any]] = []
+    using_candidates: list[dict[str, Any]] = []
+    same_file_candidates: list[dict[str, Any]] = []
+
+    for symbol in visibility.same_file_symbols:
+        if _short_name(symbol) != tail:
+            continue
+        if _same_container(symbol, visibility.current_class_name):
+            candidate = dict(symbol)
+            candidate["_basis"] = ("same_class", "same_file")
+            same_scope_candidates.append(candidate)
+        elif _same_namespace(symbol, visibility):
+            candidate = dict(symbol)
+            candidate["_basis"] = ("same_namespace", "same_file")
+            same_scope_candidates.append(candidate)
+        elif _matches_using_declaration(symbol, tail, visibility):
+            candidate = dict(symbol)
+            candidate["_basis"] = ("using_declaration",)
+            using_candidates.append(candidate)
+        elif _matches_using_directive(symbol, visibility):
+            candidate = dict(symbol)
+            candidate["_basis"] = ("using_namespace",)
+            using_candidates.append(candidate)
+        else:
+            candidate = dict(symbol)
+            candidate["_basis"] = ("same_file",)
+            same_file_candidates.append(candidate)
+
+    if same_scope_candidates:
+        return _dedupe_candidates(same_scope_candidates)
+
+    if using_candidates:
+        return _dedupe_candidates(using_candidates)
+
+    if same_file_candidates:
+        return _dedupe_candidates(same_file_candidates)
+
+    module_candidates: list[dict[str, Any]] = []
+    for symbol in visibility.visible_exported_symbols:
+        if _short_name(symbol) == tail:
+            candidate = dict(symbol)
+            candidate["_basis"] = ("module_visible",)
+            module_candidates.append(candidate)
+
+    return _dedupe_candidates(module_candidates)
+
+
+def _all_project_symbols(visibility: FunctionVisibilityContext) -> tuple[dict[str, Any], ...]:
+    return tuple(visibility.same_file_symbols) + tuple(visibility.visible_exported_symbols)
+
+
+def _dedupe_candidates(candidates: Any) -> tuple[dict[str, Any], ...]:
+    result: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        symbol_id = str(candidate.get("symbolId") or "")
+        if not symbol_id or symbol_id in seen:
+            continue
+        seen.add(symbol_id)
+        result.append(dict(candidate))
+    return tuple(result)
+
+
+def _score_candidates(candidates: Any, call: dict[str, Any]) -> tuple[dict[str, Any], ...]:
+    result = []
+    for candidate in candidates:
+        scored = dict(candidate)
+        basis = list(_candidate_basis(scored, ()))
+        score = 0.5
+        basis_weights = {
+            "qualified_name": 0.35,
+            "this_scope": 0.35,
+            "current_class": 0.3,
+            "same_class": 0.25,
+            "same_namespace": 0.18,
+            "using_declaration": 0.16,
+            "using_namespace": 0.1,
+            "local_type_hint": 0.22,
+            "member_call": 0.08,
+            "same_file": 0.08,
+            "module_visible": 0.05,
+            "namespace_alias": 0.04,
+        }
+        for item in basis:
+            score += basis_weights.get(str(item), 0.0)
+
+        arity = call.get("argumentCount")
+        if isinstance(arity, int):
+            signature_arity = _signature_arity(str(candidate.get("signature") or ""))
+            if signature_arity is not None and signature_arity == arity:
+                score += 0.12
+                if "arity_match" not in basis:
+                    basis.append("arity_match")
+            elif signature_arity is not None:
+                score -= 0.08
+                if "arity_mismatch" not in basis:
+                    basis.append("arity_mismatch")
+
+        scored["_score"] = max(0.0, min(score, 0.99))
+        scored["_basis"] = tuple(item for item in basis if item)
+        result.append(scored)
+
+    return tuple(sorted(result, key=lambda item: float(item.get("_score") or 0.0), reverse=True))
+
+
+def _candidate_basis(candidate: dict[str, Any], fallback: tuple[str, ...]) -> tuple[str, ...]:
+    basis = candidate.get("_basis")
+    if isinstance(basis, tuple):
+        return basis
+    return fallback
+
+
+def _candidate_ref(candidate: dict[str, Any]) -> dict[str, Any]:
+    result = {
+        key: candidate.get(key)
+        for key in (
+            "symbolId",
+            "shortName",
+            "qualifiedName",
+            "container",
+            "type",
+            "relativePath",
+            "startLine",
+            "endLine",
+            "signature",
+        )
+        if key in candidate
+    }
+    if "_score" in candidate:
+        result["score"] = round(float(candidate["_score"]), 3)
+    basis = _candidate_basis(candidate, ())
+    if basis:
+        result["basis"] = list(basis)
+    return result
+
+
+def _short_name(symbol: dict[str, Any]) -> str:
+    return str(symbol.get("shortName") or symbol.get("name") or "")
+
+
+def _same_container(symbol: dict[str, Any], container: str | None) -> bool:
+    if not container:
+        return False
+    symbol_container = str(symbol.get("container") or "")
+    return symbol_container.casefold() == container.casefold()
+
+
+def _same_namespace(symbol: dict[str, Any], visibility: FunctionVisibilityContext) -> bool:
+    namespace = "::".join(visibility.current_namespace)
+    if not namespace:
+        return False
+    symbol_container = str(symbol.get("container") or "")
+    return symbol_container.casefold() == namespace.casefold()
+
+
+def _matches_using_declaration(
+    symbol: dict[str, Any],
+    tail: str,
+    visibility: FunctionVisibilityContext,
+) -> bool:
+    qualified_name = str(symbol.get("qualifiedName") or "")
+    short_name = _short_name(symbol)
+    for item in visibility.using_declarations:
+        target = str(item.get("target") or item.get("targetName") or item.get("qualifiedName") or "")
+        name = str(item.get("name") or target.rsplit("::", 1)[-1])
+        if name == tail and (target == qualified_name or (not target and short_name == tail)):
+            return True
+    return False
+
+
+def _matches_using_directive(symbol: dict[str, Any], visibility: FunctionVisibilityContext) -> bool:
+    container = str(symbol.get("container") or "")
+    if not container:
+        qualified_name = str(symbol.get("qualifiedName") or "")
+        container = qualified_name.rsplit("::", 1)[0] if "::" in qualified_name else ""
+    container_folded = container.casefold()
+    for item in visibility.using_directives:
+        namespace = str(item.get("namespace") or item.get("target") or item.get("targetName") or "")
+        if namespace and container_folded == namespace.casefold():
+            return True
+    return False
+
+
+def _expand_namespace_alias(callee: str, visibility: FunctionVisibilityContext) -> str:
+    if "::" not in callee:
+        return callee
+    alias, tail = callee.split("::", 1)
+    for item in visibility.namespace_aliases:
+        item_alias = str(item.get("alias") or item.get("name") or "")
+        target = str(item.get("target") or item.get("targetName") or item.get("namespace") or "")
+        if alias == item_alias and target:
+            return f"{target}::{tail}"
+    return callee
+
+
+def _with_basis(symbol: dict[str, Any], basis: tuple[str, ...]) -> dict[str, Any]:
+    result = dict(symbol)
+    result["_basis"] = tuple(item for item in basis if item)
+    return result
+
+
+def _merge_basis(candidates: tuple[dict[str, Any], ...], fallback: tuple[str, ...]) -> tuple[str, ...]:
+    result: list[str] = []
+    for item in fallback:
+        if item and item not in result:
+            result.append(item)
+    for candidate in candidates:
+        for item in _candidate_basis(candidate, ()):
+            if item and item not in result:
+                result.append(item)
+    return tuple(result)
+
+
+def _local_type_for_object(object_name: str, visibility: FunctionVisibilityContext) -> str | None:
+    normalized = object_name.strip("*& ")
+    for item in visibility.local_declarations:
+        if str(item.get("name") or "") == normalized:
+            return _normalize_type_name(str(item.get("typeText") or ""))
+    return None
+
+
+def _normalize_type_name(type_text: str) -> str | None:
+    text = type_text.replace("const ", "").replace("*", "").replace("&", "").strip()
+    return text or None
+
+
+def _signature_arity(signature: str) -> int | None:
+    open_index = signature.find("(")
+    close_index = signature.rfind(")")
+    if open_index < 0 or close_index < open_index:
+        return None
+    args = signature[open_index + 1:close_index].strip()
+    if not args or args == "void":
+        return 0
+    depth = 0
+    count = 1
+    for char in args:
+        if char in "([{<":
+            depth += 1
+        elif char in ")]}>" and depth > 0:
+            depth -= 1
+        elif char == "," and depth == 0:
+            count += 1
+    return count
+
+
+def _callee_tail(callee: str) -> str:
+    return callee.rsplit("::", 1)[-1].rsplit("->", 1)[-1].rsplit(".", 1)[-1]
+
+
+def _call_kind(callee: str) -> str:
+    if "->" in callee or "." in callee:
+        return "member"
+    if "::" in callee:
+        return "qualified"
+    return "unqualified"

--- a/src/indexer/cpp_function_graph_resolver.py
+++ b/src/indexer/cpp_function_graph_resolver.py
@@ -11,7 +11,7 @@ from cpp_function_graph_model import (
 )
 
 
-RESOLVER_VERSION = "cpp-function-graph-resolver-v0.1"
+RESOLVER_VERSION = "cpp-function-graph-resolver-v0.2"
 EXTERNAL_QUALIFIER_PREFIXES = ("std::", "wil::", "ATL::", "Microsoft::WRL::")
 
 
@@ -19,6 +19,8 @@ def resolve_function_graph_edges(
     *,
     ast_extract: FunctionAstExtract,
     visibility: FunctionVisibilityContext,
+    include_control_flow: bool = True,
+    include_data_access: bool = True,
     include_external: bool = True,
     max_edges: int = 200,
 ) -> tuple[FunctionGraphEdge, ...]:
@@ -30,6 +32,19 @@ def resolve_function_graph_edges(
         edges.append(edge)
         if len(edges) >= max_edges:
             break
+
+    if include_data_access and len(edges) < max_edges:
+        for access in ast_extract.member_accesses:
+            edges.append(resolve_data_access(access, visibility=visibility))
+            if len(edges) >= max_edges:
+                break
+
+    if include_control_flow and len(edges) < max_edges:
+        for marker in ast_extract.control_flow:
+            edges.append(resolve_control_flow_marker(marker, visibility=visibility))
+            if len(edges) >= max_edges:
+                break
+
     return tuple(edges)
 
 
@@ -111,6 +126,51 @@ def resolve_call(
         resolution_status="external",
         confidence=0.0,
         basis=("not_in_project_symbol_index",),
+        claim_strength=SOURCE_STRUCTURE_CLAIM_STRENGTH,
+        behavior_claims_allowed=BEHAVIOR_CLAIMS_ALLOWED,
+    )
+
+
+def resolve_data_access(
+    access: dict[str, Any],
+    *,
+    visibility: FunctionVisibilityContext,
+) -> FunctionGraphEdge:
+    text = str(access.get("text") or "")
+    access_kind = str(access.get("accessKind") or "")
+    edge_kind = "writes_data_candidate" if access_kind == "write_candidate" else "reads_data_candidate"
+    candidates = _data_candidates(text, visibility)
+    status = "probable" if candidates else "unresolved"
+    basis = _merge_data_basis(candidates, ("member_access", access_kind or "read_candidate"))
+    return FunctionGraphEdge(
+        from_symbol_id=visibility.function_symbol_id,
+        edge_kind=edge_kind,
+        to_text=text,
+        to_symbol_id=None,
+        resolution_status=status,
+        confidence=0.74 if candidates else 0.0,
+        basis=basis,
+        candidates=tuple(_data_candidate_ref(candidate) for candidate in candidates),
+        claim_strength=SOURCE_STRUCTURE_CLAIM_STRENGTH,
+        behavior_claims_allowed=BEHAVIOR_CLAIMS_ALLOWED,
+    )
+
+
+def resolve_control_flow_marker(
+    marker: dict[str, Any],
+    *,
+    visibility: FunctionVisibilityContext,
+) -> FunctionGraphEdge:
+    text = str(marker.get("marker") or marker.get("text") or "")
+    return FunctionGraphEdge(
+        from_symbol_id=visibility.function_symbol_id,
+        edge_kind="control_flow_marker",
+        to_text=text,
+        to_symbol_id=None,
+        resolution_status="exact",
+        confidence=1.0,
+        basis=("raw_syntax", "control_flow_marker"),
+        candidates=(),
         claim_strength=SOURCE_STRUCTURE_CLAIM_STRENGTH,
         behavior_claims_allowed=BEHAVIOR_CLAIMS_ALLOWED,
     )
@@ -213,6 +273,25 @@ def _all_project_symbols(visibility: FunctionVisibilityContext) -> tuple[dict[st
     return tuple(visibility.same_file_symbols) + tuple(visibility.visible_exported_symbols)
 
 
+def _all_indexed_data(visibility: FunctionVisibilityContext) -> tuple[dict[str, Any], ...]:
+    return tuple(visibility.member_data) + tuple(visibility.same_file_data)
+
+
+def _data_candidates(text: str, visibility: FunctionVisibilityContext) -> tuple[dict[str, Any], ...]:
+    tail = _member_tail(text)
+    result: list[dict[str, Any]] = []
+    for item in _all_indexed_data(visibility):
+        if _data_name(item) != tail:
+            continue
+        candidate = dict(item)
+        if item in visibility.member_data:
+            candidate["_basis"] = ("indexed_member_data",)
+        else:
+            candidate["_basis"] = ("indexed_same_file_data",)
+        result.append(candidate)
+    return _dedupe_data_candidates(result)
+
+
 def _dedupe_candidates(candidates: Any) -> tuple[dict[str, Any], ...]:
     result: list[dict[str, Any]] = []
     seen: set[str] = set()
@@ -221,6 +300,18 @@ def _dedupe_candidates(candidates: Any) -> tuple[dict[str, Any], ...]:
         if not symbol_id or symbol_id in seen:
             continue
         seen.add(symbol_id)
+        result.append(dict(candidate))
+    return tuple(result)
+
+
+def _dedupe_data_candidates(candidates: Any) -> tuple[dict[str, Any], ...]:
+    result: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        data_id = str(candidate.get("dataId") or "")
+        if not data_id or data_id in seen:
+            continue
+        seen.add(data_id)
         result.append(dict(candidate))
     return tuple(result)
 
@@ -292,6 +383,29 @@ def _candidate_ref(candidate: dict[str, Any]) -> dict[str, Any]:
     }
     if "_score" in candidate:
         result["score"] = round(float(candidate["_score"]), 3)
+    basis = _candidate_basis(candidate, ())
+    if basis:
+        result["basis"] = list(basis)
+    return result
+
+
+def _data_candidate_ref(candidate: dict[str, Any]) -> dict[str, Any]:
+    result = {
+        key: candidate.get(key)
+        for key in (
+            "dataId",
+            "name",
+            "shortName",
+            "qualifiedName",
+            "container",
+            "typeText",
+            "relativePath",
+            "startLine",
+            "endLine",
+            "signature",
+        )
+        if key in candidate
+    }
     basis = _candidate_basis(candidate, ())
     if basis:
         result["basis"] = list(basis)
@@ -410,6 +524,26 @@ def _signature_arity(signature: str) -> int | None:
 
 def _callee_tail(callee: str) -> str:
     return callee.rsplit("::", 1)[-1].rsplit("->", 1)[-1].rsplit(".", 1)[-1]
+
+
+def _member_tail(text: str) -> str:
+    return text.rsplit("::", 1)[-1].rsplit("->", 1)[-1].rsplit(".", 1)[-1]
+
+
+def _data_name(item: dict[str, Any]) -> str:
+    return str(item.get("shortName") or item.get("name") or "").rsplit("::", 1)[-1]
+
+
+def _merge_data_basis(candidates: tuple[dict[str, Any], ...], fallback: tuple[str, ...]) -> tuple[str, ...]:
+    result: list[str] = []
+    for item in fallback:
+        if item and item not in result:
+            result.append(item)
+    for candidate in candidates:
+        for item in _candidate_basis(candidate, ()):
+            if item and item not in result:
+                result.append(item)
+    return tuple(result)
 
 
 def _call_kind(callee: str) -> str:

--- a/src/indexer/cpp_function_graph_service.py
+++ b/src/indexer/cpp_function_graph_service.py
@@ -194,6 +194,7 @@ class FunctionGraphSourceService:
             else request_or_symbol_id
         )
         source = self.extract_function_source(request.symbol_id)
+        cache_resolver_version = _cache_resolver_version(request)
         graph_key = FunctionGraphCacheKey(
             function_symbol_id=source.symbol_id,
             function_body_fingerprint=source.function_body_fingerprint,
@@ -202,7 +203,7 @@ class FunctionGraphSourceService:
             module_visibility_fingerprint=module_visibility_fingerprint,
             parser_id=self.parser.parser_id,
             parser_version=self.parser.parser_version,
-            resolver_version=RESOLVER_VERSION,
+            resolver_version=cache_resolver_version,
         )
 
         if self.storage is not None and request.mode != "refresh":
@@ -227,6 +228,7 @@ class FunctionGraphSourceService:
                             "functionBodyFingerprint": source.function_body_fingerprint,
                             "parser": self.parser.parser_id,
                             "resolver": RESOLVER_VERSION,
+                            "cacheResolver": cache_resolver_version,
                         }
                     ),
                     file=file_fingerprint,
@@ -266,6 +268,8 @@ class FunctionGraphSourceService:
         edges = resolve_function_graph_edges(
             ast_extract=ast_extract,
             visibility=visibility,
+            include_control_flow=request.include_control_flow,
+            include_data_access=request.include_data_access,
             include_external=request.include_external,
             max_edges=request.max_edges,
         )
@@ -279,6 +283,7 @@ class FunctionGraphSourceService:
                     "version": ast_extract.parser_version,
                 },
                 "resolverVersion": RESOLVER_VERSION,
+                "cacheResolverVersion": cache_resolver_version,
                 "edges": [asdict(edge) for edge in edges],
             }
         )
@@ -488,3 +493,13 @@ def _unique_edge_symbol_ids(edges: tuple[dict[str, Any], ...], *, key: str) -> t
         seen.add(value)
         result.append(value)
     return tuple(result)
+
+
+def _cache_resolver_version(request: FunctionGraphRequest) -> str:
+    return (
+        f"{RESOLVER_VERSION};"
+        f"cf={int(request.include_control_flow)};"
+        f"da={int(request.include_data_access)};"
+        f"ex={int(request.include_external)};"
+        f"max={request.max_edges}"
+    )

--- a/src/indexer/cpp_function_graph_service.py
+++ b/src/indexer/cpp_function_graph_service.py
@@ -1,0 +1,490 @@
+from __future__ import annotations
+
+import hashlib
+import json
+
+from dataclasses import asdict, replace
+from pathlib import Path
+from typing import Any
+
+from cpp_function_graph_cache import (
+    FunctionAstCacheKey,
+    FunctionGraphCacheKey,
+    ast_cache_key_for_extract,
+    stable_json_fingerprint,
+)
+from cpp_function_graph_extract import EXTRACTOR_VERSION, LightweightFunctionBodyParser
+from cpp_function_graph_model import (
+    BEHAVIOR_CLAIMS_ALLOWED,
+    FUNCTION_GRAPH_SCHEMA,
+    SOURCE_STRUCTURE_CLAIM_STRENGTH,
+    FunctionGraphError,
+    FunctionGraphFingerprints,
+    FunctionGraphRequest,
+    FunctionGraphResult,
+    FunctionSourceSlice,
+)
+from cpp_function_graph_resolver import RESOLVER_VERSION, resolve_function_graph_edges
+from cpp_function_graph_storage import FunctionGraphStorage
+from cpp_function_graph_visibility import build_function_visibility_context
+from cpp_project_index import CODE_ENTITY_CALLABLE_SYMBOL_TYPES
+
+
+FUNCTION_GRAPH_XREF_SCHEMA = "cpp.function_graph_xrefs.v0.1"
+FUNCTION_GRAPH_NEIGHBORHOOD_SCHEMA = "cpp.function_graph_neighborhood.v0.1"
+
+
+class FunctionGraphSourceError(ValueError):
+    def __init__(self, error: FunctionGraphError) -> None:
+        super().__init__(error.message)
+        self.error = error
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self.error)
+
+
+def text_fingerprint(text: str) -> str:
+    return "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def stable_payload_fingerprint(payload: dict[str, Any]) -> str:
+    text = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return text_fingerprint(text)
+
+
+class FunctionGraphSourceService:
+    def __init__(
+        self,
+        *,
+        project_root: Path,
+        index: Any,
+        index_root: Path | None = None,
+        parser: Any | None = None,
+        storage: FunctionGraphStorage | None = None,
+    ) -> None:
+        self.project_root = project_root
+        self.index = index
+        self.index_root = index_root
+        self.parser = parser or LightweightFunctionBodyParser()
+        self.storage = storage or (FunctionGraphStorage.from_index_root(index_root) if index_root is not None else None)
+
+    def extract_function_source(self, symbol_id: str) -> FunctionSourceSlice:
+        symbol = self._symbol_by_id(symbol_id)
+        symbol_type = str(symbol.get("type") or "")
+
+        if symbol_type not in CODE_ENTITY_CALLABLE_SYMBOL_TYPES:
+            raise FunctionGraphSourceError(
+                FunctionGraphError(
+                    code="not_callable_symbol",
+                    message=f"Symbol {symbol_id!r} is not an indexed callable symbol.",
+                    symbol_id=symbol_id,
+                )
+            )
+
+        file_id = str(symbol.get("fileId") or "")
+        file_item = self._file_by_id(file_id, symbol_id=symbol_id)
+        relative_path = str(file_item.get("relativePath") or file_id)
+        source_path = self.project_root / relative_path
+
+        if not source_path.exists():
+            raise FunctionGraphSourceError(
+                FunctionGraphError(
+                    code="source_file_missing",
+                    message=f"Source file for symbol {symbol_id!r} does not exist: {relative_path}",
+                    symbol_id=symbol_id,
+                )
+            )
+
+        start_line = int(symbol.get("startLine") or 0)
+        end_line = int(symbol.get("endLine") or 0)
+        if start_line < 1 or end_line < start_line:
+            raise FunctionGraphSourceError(
+                FunctionGraphError(
+                    code="invalid_symbol_range",
+                    message=f"Symbol {symbol_id!r} has an invalid source range.",
+                    symbol_id=symbol_id,
+                )
+            )
+
+        source_text = source_path.read_text(encoding="utf-8", errors="replace")
+        lines = source_text.splitlines(keepends=True)
+
+        if start_line > len(lines):
+            raise FunctionGraphSourceError(
+                FunctionGraphError(
+                    code="symbol_range_out_of_file",
+                    message=f"Symbol {symbol_id!r} starts beyond the end of {relative_path}.",
+                    symbol_id=symbol_id,
+                )
+            )
+
+        end_line = min(end_line, len(lines))
+        function_text = "".join(lines[start_line - 1:end_line])
+        base_byte = len("".join(lines[:start_line - 1]).encode("utf-8"))
+
+        return FunctionSourceSlice(
+            symbol_id=symbol_id,
+            function_name=str(symbol.get("shortName") or "") or None,
+            qualified_name=str(symbol.get("qualifiedName") or "") or None,
+            symbol_type=symbol_type,
+            file_id=file_id,
+            relative_path=relative_path,
+            start_line=start_line,
+            end_line=end_line,
+            base_line=start_line,
+            base_byte=base_byte,
+            text=function_text,
+            function_body_fingerprint=text_fingerprint(function_text),
+        )
+
+    def build_empty_graph_result(
+        self,
+        request_or_symbol_id: FunctionGraphRequest | str,
+    ) -> FunctionGraphResult:
+        request = (
+            FunctionGraphRequest(symbol_id=request_or_symbol_id)
+            if isinstance(request_or_symbol_id, str)
+            else request_or_symbol_id
+        )
+        source = self.extract_function_source(request.symbol_id)
+        graph_fingerprint = stable_payload_fingerprint(
+            {
+                "schema": FUNCTION_GRAPH_SCHEMA,
+                "symbolId": source.symbol_id,
+                "functionBodyFingerprint": source.function_body_fingerprint,
+                "edges": [],
+                "parser": None,
+                "resolver": None,
+            }
+        )
+
+        return FunctionGraphResult(
+            schema=FUNCTION_GRAPH_SCHEMA,
+            status="computed",
+            from_cache=False,
+            symbol_id=source.symbol_id,
+            function_name=source.function_name,
+            qualified_name=source.qualified_name,
+            file=source.relative_path,
+            start_line=source.start_line,
+            end_line=source.end_line,
+            parser_id=None,
+            parser_version=None,
+            resolver_version=None,
+            claim_strength=SOURCE_STRUCTURE_CLAIM_STRENGTH,
+            behavior_claims_allowed=BEHAVIOR_CLAIMS_ALLOWED,
+            fingerprints=FunctionGraphFingerprints(
+                function_body=source.function_body_fingerprint,
+                graph=graph_fingerprint,
+            ),
+            edges=(),
+        )
+
+    def get_function_body_graph(
+        self,
+        request_or_symbol_id: FunctionGraphRequest | str,
+        *,
+        file_fingerprint: str,
+        symbol_index_fingerprint: str,
+        module_visibility_fingerprint: str,
+    ) -> FunctionGraphResult:
+        request = (
+            FunctionGraphRequest(symbol_id=request_or_symbol_id)
+            if isinstance(request_or_symbol_id, str)
+            else request_or_symbol_id
+        )
+        source = self.extract_function_source(request.symbol_id)
+        graph_key = FunctionGraphCacheKey(
+            function_symbol_id=source.symbol_id,
+            function_body_fingerprint=source.function_body_fingerprint,
+            file_fingerprint=file_fingerprint,
+            symbol_index_fingerprint=symbol_index_fingerprint,
+            module_visibility_fingerprint=module_visibility_fingerprint,
+            parser_id=self.parser.parser_id,
+            parser_version=self.parser.parser_version,
+            resolver_version=RESOLVER_VERSION,
+        )
+
+        if self.storage is not None and request.mode != "refresh":
+            cached = self.storage.load_graph_result(graph_key)
+            if cached is not None:
+                return replace(cached, from_cache=True, status="computed")
+
+        if request.mode == "cache_only":
+            return replace(
+                self.build_empty_graph_result(request),
+                status="cache_miss",
+                parser_id=self.parser.parser_id,
+                parser_version=self.parser.parser_version,
+                resolver_version=RESOLVER_VERSION,
+                fingerprints=FunctionGraphFingerprints(
+                    function_body=source.function_body_fingerprint,
+                    graph=stable_json_fingerprint(
+                        {
+                            "schema": FUNCTION_GRAPH_SCHEMA,
+                            "status": "cache_miss",
+                            "symbolId": source.symbol_id,
+                            "functionBodyFingerprint": source.function_body_fingerprint,
+                            "parser": self.parser.parser_id,
+                            "resolver": RESOLVER_VERSION,
+                        }
+                    ),
+                    file=file_fingerprint,
+                    symbol_index=symbol_index_fingerprint,
+                    module_visibility=module_visibility_fingerprint,
+                ),
+            )
+
+        ast_extract = None
+        if self.storage is not None and request.mode != "refresh":
+            ast_extract = self.storage.load_ast_extract(
+                FunctionAstCacheKey(
+                    function_symbol_id=source.symbol_id,
+                    function_body_fingerprint=source.function_body_fingerprint,
+                    parser_id=self.parser.parser_id,
+                    parser_version=self.parser.parser_version,
+                    extractor_version=EXTRACTOR_VERSION,
+                )
+            )
+
+        if ast_extract is None:
+            ast_extract = self.parser.parse_function(
+                symbol_id=source.symbol_id,
+                source_fingerprint=source.function_body_fingerprint,
+                function_text=source.text,
+                base_line=source.base_line,
+                base_byte=source.base_byte,
+            )
+            if self.storage is not None:
+                self.storage.store_ast_extract(ast_cache_key_for_extract(ast_extract), ast_extract)
+
+        visibility = build_function_visibility_context(
+            index=self.index,
+            source=source,
+            ast_extract=ast_extract,
+        )
+        edges = resolve_function_graph_edges(
+            ast_extract=ast_extract,
+            visibility=visibility,
+            include_external=request.include_external,
+            max_edges=request.max_edges,
+        )
+        graph_fingerprint = stable_json_fingerprint(
+            {
+                "schema": FUNCTION_GRAPH_SCHEMA,
+                "symbolId": source.symbol_id,
+                "functionBodyFingerprint": source.function_body_fingerprint,
+                "parser": {
+                    "id": ast_extract.parser_id,
+                    "version": ast_extract.parser_version,
+                },
+                "resolverVersion": RESOLVER_VERSION,
+                "edges": [asdict(edge) for edge in edges],
+            }
+        )
+        result = FunctionGraphResult(
+            schema=FUNCTION_GRAPH_SCHEMA,
+            status="computed",
+            from_cache=False,
+            symbol_id=source.symbol_id,
+            function_name=source.function_name,
+            qualified_name=source.qualified_name,
+            file=source.relative_path,
+            start_line=source.start_line,
+            end_line=source.end_line,
+            parser_id=ast_extract.parser_id,
+            parser_version=ast_extract.parser_version,
+            resolver_version=RESOLVER_VERSION,
+            claim_strength=SOURCE_STRUCTURE_CLAIM_STRENGTH,
+            behavior_claims_allowed=BEHAVIOR_CLAIMS_ALLOWED,
+            fingerprints=FunctionGraphFingerprints(
+                function_body=source.function_body_fingerprint,
+                graph=graph_fingerprint,
+                file=file_fingerprint,
+                symbol_index=symbol_index_fingerprint,
+                module_visibility=module_visibility_fingerprint,
+            ),
+            edges=edges,
+        )
+
+        if self.storage is not None:
+            self.storage.store_graph_result(graph_key, result)
+
+        return result
+
+    def get_call_xrefs_from(self, symbol_id: str, *, limit: int = 200) -> dict[str, Any]:
+        self._symbol_by_id(symbol_id)
+        storage = self._require_storage()
+        edges = storage.list_edges_from(symbol_id, limit=limit)
+        return {
+            "schema": FUNCTION_GRAPH_XREF_SCHEMA,
+            "status": "computed",
+            "direction": "from",
+            "symbolId": symbol_id,
+            "symbol": self._compact_symbol(symbol_id),
+            "returnedEdges": len(edges),
+            "claimStrength": SOURCE_STRUCTURE_CLAIM_STRENGTH,
+            "behaviorClaimsAllowed": BEHAVIOR_CLAIMS_ALLOWED,
+            "edges": list(edges),
+        }
+
+    def get_call_xrefs_to(self, symbol_id: str, *, limit: int = 200) -> dict[str, Any]:
+        self._symbol_by_id(symbol_id)
+        storage = self._require_storage()
+        edges = storage.list_edges_to(symbol_id, limit=limit)
+        return {
+            "schema": FUNCTION_GRAPH_XREF_SCHEMA,
+            "status": "computed",
+            "direction": "to",
+            "symbolId": symbol_id,
+            "symbol": self._compact_symbol(symbol_id),
+            "returnedEdges": len(edges),
+            "claimStrength": SOURCE_STRUCTURE_CLAIM_STRENGTH,
+            "behaviorClaimsAllowed": BEHAVIOR_CLAIMS_ALLOWED,
+            "edges": list(edges),
+        }
+
+    def get_symbol_neighborhood(
+        self,
+        symbol_id: str,
+        *,
+        incoming_limit: int = 100,
+        outgoing_limit: int = 100,
+    ) -> dict[str, Any]:
+        self._symbol_by_id(symbol_id)
+        storage = self._require_storage()
+        incoming_edges = storage.list_edges_to(symbol_id, limit=incoming_limit)
+        outgoing_edges = storage.list_edges_from(symbol_id, limit=outgoing_limit)
+        return {
+            "schema": FUNCTION_GRAPH_NEIGHBORHOOD_SCHEMA,
+            "status": "computed",
+            "symbolId": symbol_id,
+            "target": self._compact_symbol(symbol_id),
+            "callerCount": len(_unique_edge_symbol_ids(incoming_edges, key="fromSymbolId")),
+            "calleeCount": len(_unique_edge_symbol_ids(outgoing_edges, key="toSymbolId")),
+            "incomingEdgeCount": len(incoming_edges),
+            "outgoingEdgeCount": len(outgoing_edges),
+            "claimStrength": SOURCE_STRUCTURE_CLAIM_STRENGTH,
+            "behaviorClaimsAllowed": BEHAVIOR_CLAIMS_ALLOWED,
+            "callers": [
+                self._compact_symbol(caller_id)
+                for caller_id in _unique_edge_symbol_ids(incoming_edges, key="fromSymbolId")
+            ],
+            "callees": [
+                self._compact_symbol(callee_id)
+                for callee_id in _unique_edge_symbol_ids(outgoing_edges, key="toSymbolId")
+            ],
+            "incomingEdges": list(incoming_edges),
+            "outgoingEdges": list(outgoing_edges),
+        }
+
+    def _symbol_by_id(self, symbol_id: str) -> dict[str, Any]:
+        symbol = self.index.symbol_by_id.get(symbol_id)
+
+        if symbol is None:
+            raise FunctionGraphSourceError(
+                FunctionGraphError(
+                    code="symbol_not_found",
+                    message=f"Symbol {symbol_id!r} was not found in the loaded index.",
+                    symbol_id=symbol_id,
+                )
+            )
+
+        return dict(symbol)
+
+    def _file_by_id(self, file_id: str, *, symbol_id: str) -> dict[str, Any]:
+        file_item = self.index.file_by_id.get(file_id)
+
+        if file_item is None:
+            raise FunctionGraphSourceError(
+                FunctionGraphError(
+                    code="file_not_found",
+                    message=f"File {file_id!r} for symbol {symbol_id!r} was not found in the loaded index.",
+                    symbol_id=symbol_id,
+                )
+            )
+
+        return dict(file_item)
+
+    def _require_storage(self) -> FunctionGraphStorage:
+        if self.storage is None:
+            raise FunctionGraphSourceError(
+                FunctionGraphError(
+                    code="graph_storage_unavailable",
+                    message="Function graph storage is not configured for this index.",
+                )
+            )
+
+        return self.storage
+
+    def _compact_symbol(self, symbol_id: str) -> dict[str, Any]:
+        symbol = self._symbol_by_id(symbol_id)
+        file_id = str(symbol.get("fileId") or "")
+        file_item = self.index.file_by_id.get(file_id) or {}
+        return {
+            "symbolId": symbol_id,
+            "kind": symbol.get("type"),
+            "name": symbol.get("shortName"),
+            "qualifiedName": symbol.get("qualifiedName"),
+            "file": file_item.get("relativePath") or symbol.get("relativePath"),
+            "startLine": symbol.get("startLine"),
+            "endLine": symbol.get("endLine"),
+        }
+
+
+def function_graph_result_to_api(result: FunctionGraphResult) -> dict[str, Any]:
+    return {
+        "schema": result.schema,
+        "status": result.status,
+        "fromCache": result.from_cache,
+        "symbolId": result.symbol_id,
+        "functionName": result.function_name,
+        "qualifiedName": result.qualified_name,
+        "file": result.file,
+        "range": {
+            "startLine": result.start_line,
+            "endLine": result.end_line,
+        },
+        "parser": {
+            "id": result.parser_id,
+            "version": result.parser_version,
+        },
+        "resolver": {
+            "version": result.resolver_version,
+        },
+        "claimStrength": result.claim_strength,
+        "behaviorClaimsAllowed": result.behavior_claims_allowed,
+        "fingerprints": {
+            "functionBody": result.fingerprints.function_body,
+            "file": result.fingerprints.file,
+            "symbolIndex": result.fingerprints.symbol_index,
+            "moduleVisibility": result.fingerprints.module_visibility,
+            "graph": result.fingerprints.graph,
+        },
+        "edges": [
+            {
+                "edgeKind": edge.edge_kind,
+                "toText": edge.to_text,
+                "toSymbolId": edge.to_symbol_id,
+                "resolutionStatus": edge.resolution_status,
+                "confidence": edge.confidence,
+                "basis": list(edge.basis),
+                "candidates": list(edge.candidates),
+                "claimStrength": edge.claim_strength,
+                "behaviorClaimsAllowed": edge.behavior_claims_allowed,
+            }
+            for edge in result.edges
+        ],
+    }
+
+
+def _unique_edge_symbol_ids(edges: tuple[dict[str, Any], ...], *, key: str) -> tuple[str, ...]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for edge in edges:
+        value = edge.get(key)
+        if not isinstance(value, str) or not value or value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return tuple(result)

--- a/src/indexer/cpp_function_graph_storage.py
+++ b/src/indexer/cpp_function_graph_storage.py
@@ -1,0 +1,367 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from cpp_function_graph_cache import FunctionAstCacheKey, FunctionGraphCacheKey
+from cpp_function_graph_model import (
+    FunctionAstExtract,
+    FunctionGraphEdge,
+    FunctionGraphFingerprints,
+    FunctionGraphResult,
+)
+from cpp_index_sqlite import connect_index_db, sqlite_index_path
+
+
+FUNCTION_GRAPH_STORAGE_SCHEMA = "cpp.function_graph.sqlite.v0.1"
+
+
+def function_graph_db_path(index_root: Path) -> Path:
+    return sqlite_index_path(index_root)
+
+
+def initialize_function_graph_storage(connection: sqlite3.Connection) -> None:
+    connection.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS function_ast_extract_cache (
+            function_symbol_id TEXT NOT NULL,
+            function_body_fingerprint TEXT NOT NULL,
+            parser_id TEXT NOT NULL,
+            parser_version TEXT NOT NULL,
+            extractor_version TEXT NOT NULL,
+            payload_json TEXT NOT NULL,
+            created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY(
+                function_symbol_id,
+                function_body_fingerprint,
+                parser_id,
+                parser_version,
+                extractor_version
+            )
+        );
+
+        CREATE TABLE IF NOT EXISTS function_graph_cache (
+            function_symbol_id TEXT NOT NULL,
+            graph_fingerprint TEXT NOT NULL,
+            function_body_fingerprint TEXT NOT NULL,
+            file_fingerprint TEXT NOT NULL,
+            symbol_index_fingerprint TEXT NOT NULL,
+            module_visibility_fingerprint TEXT NOT NULL,
+            parser_id TEXT NOT NULL,
+            parser_version TEXT NOT NULL,
+            resolver_version TEXT NOT NULL,
+            payload_json TEXT NOT NULL,
+            created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY(function_symbol_id, graph_fingerprint)
+        );
+
+        CREATE TABLE IF NOT EXISTS function_graph_edges (
+            graph_fingerprint TEXT NOT NULL,
+            from_symbol_id TEXT NOT NULL,
+            to_symbol_id TEXT,
+            to_text TEXT NOT NULL,
+            edge_kind TEXT NOT NULL,
+            resolution_status TEXT NOT NULL,
+            confidence REAL NOT NULL,
+            claim_strength TEXT NOT NULL,
+            behavior_claims_allowed INTEGER NOT NULL,
+            basis_json TEXT NOT NULL,
+            evidence_json TEXT NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_function_graph_cache_lookup
+            ON function_graph_cache(
+                function_symbol_id,
+                function_body_fingerprint,
+                file_fingerprint,
+                symbol_index_fingerprint,
+                module_visibility_fingerprint,
+                parser_id,
+                parser_version,
+                resolver_version
+            );
+
+        CREATE INDEX IF NOT EXISTS idx_function_graph_edges_from
+            ON function_graph_edges(from_symbol_id);
+
+        CREATE INDEX IF NOT EXISTS idx_function_graph_edges_to
+            ON function_graph_edges(to_symbol_id);
+        """
+    )
+
+
+class FunctionGraphStorage:
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+
+    @classmethod
+    def from_index_root(cls, index_root: Path) -> "FunctionGraphStorage":
+        return cls(function_graph_db_path(index_root))
+
+    def connect(self) -> sqlite3.Connection:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        connection = connect_index_db(self.db_path)
+        initialize_function_graph_storage(connection)
+        return connection
+
+    def store_ast_extract(self, key: FunctionAstCacheKey, extract: FunctionAstExtract) -> None:
+        with self.connect() as connection:
+            connection.execute(
+                """
+                INSERT OR REPLACE INTO function_ast_extract_cache(
+                    function_symbol_id,
+                    function_body_fingerprint,
+                    parser_id,
+                    parser_version,
+                    extractor_version,
+                    payload_json
+                )
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    key.function_symbol_id,
+                    key.function_body_fingerprint,
+                    key.parser_id,
+                    key.parser_version,
+                    key.extractor_version,
+                    _json_dump(asdict(extract)),
+                ),
+            )
+
+    def load_ast_extract(self, key: FunctionAstCacheKey) -> FunctionAstExtract | None:
+        with self.connect() as connection:
+            row = connection.execute(
+                """
+                SELECT payload_json
+                FROM function_ast_extract_cache
+                WHERE function_symbol_id = ?
+                  AND function_body_fingerprint = ?
+                  AND parser_id = ?
+                  AND parser_version = ?
+                  AND extractor_version = ?
+                """,
+                (
+                    key.function_symbol_id,
+                    key.function_body_fingerprint,
+                    key.parser_id,
+                    key.parser_version,
+                    key.extractor_version,
+                ),
+            ).fetchone()
+
+        if row is None:
+            return None
+
+        return _ast_extract_from_payload(json.loads(str(row["payload_json"])))
+
+    def store_graph_result(self, key: FunctionGraphCacheKey, result: FunctionGraphResult) -> None:
+        graph_fingerprint = result.fingerprints.graph
+        with self.connect() as connection:
+            connection.execute(
+                """
+                INSERT OR REPLACE INTO function_graph_cache(
+                    function_symbol_id,
+                    graph_fingerprint,
+                    function_body_fingerprint,
+                    file_fingerprint,
+                    symbol_index_fingerprint,
+                    module_visibility_fingerprint,
+                    parser_id,
+                    parser_version,
+                    resolver_version,
+                    payload_json
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    key.function_symbol_id,
+                    graph_fingerprint,
+                    key.function_body_fingerprint,
+                    key.file_fingerprint,
+                    key.symbol_index_fingerprint,
+                    key.module_visibility_fingerprint,
+                    key.parser_id,
+                    key.parser_version,
+                    key.resolver_version,
+                    _json_dump(asdict(result)),
+                ),
+            )
+            connection.execute(
+                "DELETE FROM function_graph_edges WHERE from_symbol_id = ?",
+                (key.function_symbol_id,),
+            )
+            connection.executemany(
+                """
+                INSERT INTO function_graph_edges(
+                    graph_fingerprint,
+                    from_symbol_id,
+                    to_symbol_id,
+                    to_text,
+                    edge_kind,
+                    resolution_status,
+                    confidence,
+                    claim_strength,
+                    behavior_claims_allowed,
+                    basis_json,
+                    evidence_json
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    (
+                        graph_fingerprint,
+                        edge.from_symbol_id,
+                        edge.to_symbol_id,
+                        edge.to_text,
+                        edge.edge_kind,
+                        edge.resolution_status,
+                        float(edge.confidence),
+                        edge.claim_strength,
+                        1 if edge.behavior_claims_allowed else 0,
+                        _json_dump(list(edge.basis)),
+                        _json_dump({"candidates": list(edge.candidates)}),
+                    )
+                    for edge in result.edges
+                ],
+            )
+
+    def load_graph_result(self, key: FunctionGraphCacheKey) -> FunctionGraphResult | None:
+        with self.connect() as connection:
+            row = connection.execute(
+                """
+                SELECT payload_json
+                FROM function_graph_cache
+                WHERE function_symbol_id = ?
+                  AND function_body_fingerprint = ?
+                  AND file_fingerprint = ?
+                  AND symbol_index_fingerprint = ?
+                  AND module_visibility_fingerprint = ?
+                  AND parser_id = ?
+                  AND parser_version = ?
+                  AND resolver_version = ?
+                ORDER BY created_at DESC
+                LIMIT 1
+                """,
+                (
+                    key.function_symbol_id,
+                    key.function_body_fingerprint,
+                    key.file_fingerprint,
+                    key.symbol_index_fingerprint,
+                    key.module_visibility_fingerprint,
+                    key.parser_id,
+                    key.parser_version,
+                    key.resolver_version,
+                ),
+            ).fetchone()
+
+        if row is None:
+            return None
+
+        return _graph_result_from_payload(json.loads(str(row["payload_json"])))
+
+    def list_edges_from(self, symbol_id: str, *, limit: int = 200) -> tuple[dict[str, Any], ...]:
+        return self._list_edges("from_symbol_id", symbol_id, limit=limit)
+
+    def list_edges_to(self, symbol_id: str, *, limit: int = 200) -> tuple[dict[str, Any], ...]:
+        return self._list_edges("to_symbol_id", symbol_id, limit=limit)
+
+    def _list_edges(self, column: str, symbol_id: str, *, limit: int) -> tuple[dict[str, Any], ...]:
+        if column not in {"from_symbol_id", "to_symbol_id"}:
+            raise ValueError("Invalid edge lookup column.")
+
+        safe_limit = max(0, min(int(limit), 1000))
+        with self.connect() as connection:
+            rows = connection.execute(
+                f"""
+                SELECT *
+                FROM function_graph_edges
+                WHERE {column} = ?
+                ORDER BY graph_fingerprint, edge_kind, to_text
+                LIMIT ?
+                """,
+                (symbol_id, safe_limit),
+            ).fetchall()
+
+        return tuple(_edge_row_to_dict(row) for row in rows)
+
+
+def _ast_extract_from_payload(payload: dict[str, Any]) -> FunctionAstExtract:
+    return FunctionAstExtract(
+        symbol_id=str(payload["symbol_id"]),
+        source_fingerprint=str(payload["source_fingerprint"]),
+        parser_id=str(payload["parser_id"]),
+        parser_version=str(payload["parser_version"]),
+        extractor_version=str(payload["extractor_version"]),
+        calls=tuple(payload.get("calls") or ()),
+        member_accesses=tuple(payload.get("member_accesses") or ()),
+        local_declarations=tuple(payload.get("local_declarations") or ()),
+        control_flow=tuple(payload.get("control_flow") or ()),
+    )
+
+
+def _graph_result_from_payload(payload: dict[str, Any]) -> FunctionGraphResult:
+    fingerprints_payload = payload["fingerprints"]
+    return FunctionGraphResult(
+        schema=str(payload["schema"]),
+        status=str(payload["status"]),
+        from_cache=bool(payload["from_cache"]),
+        symbol_id=str(payload["symbol_id"]),
+        function_name=payload.get("function_name"),
+        qualified_name=payload.get("qualified_name"),
+        file=str(payload["file"]),
+        start_line=int(payload["start_line"]),
+        end_line=int(payload["end_line"]),
+        parser_id=payload.get("parser_id"),
+        parser_version=payload.get("parser_version"),
+        resolver_version=payload.get("resolver_version"),
+        claim_strength=str(payload["claim_strength"]),
+        behavior_claims_allowed=bool(payload["behavior_claims_allowed"]),
+        fingerprints=FunctionGraphFingerprints(
+            function_body=str(fingerprints_payload["function_body"]),
+            graph=str(fingerprints_payload["graph"]),
+            file=fingerprints_payload.get("file"),
+            symbol_index=fingerprints_payload.get("symbol_index"),
+            module_visibility=fingerprints_payload.get("module_visibility"),
+        ),
+        edges=tuple(_edge_from_payload(item) for item in payload.get("edges") or ()),
+    )
+
+
+def _edge_from_payload(payload: dict[str, Any]) -> FunctionGraphEdge:
+    return FunctionGraphEdge(
+        from_symbol_id=str(payload["from_symbol_id"]),
+        edge_kind=payload["edge_kind"],
+        to_text=str(payload["to_text"]),
+        to_symbol_id=payload.get("to_symbol_id"),
+        resolution_status=payload["resolution_status"],
+        confidence=float(payload["confidence"]),
+        basis=tuple(payload.get("basis") or ()),
+        candidates=tuple(payload.get("candidates") or ()),
+        claim_strength=str(payload["claim_strength"]),
+        behavior_claims_allowed=bool(payload["behavior_claims_allowed"]),
+    )
+
+
+def _edge_row_to_dict(row: sqlite3.Row) -> dict[str, Any]:
+    evidence = json.loads(str(row["evidence_json"] or "{}"))
+    return {
+        "graphFingerprint": row["graph_fingerprint"],
+        "fromSymbolId": row["from_symbol_id"],
+        "toSymbolId": row["to_symbol_id"],
+        "toText": row["to_text"],
+        "edgeKind": row["edge_kind"],
+        "resolutionStatus": row["resolution_status"],
+        "confidence": float(row["confidence"]),
+        "claimStrength": row["claim_strength"],
+        "behaviorClaimsAllowed": bool(row["behavior_claims_allowed"]),
+        "basis": json.loads(str(row["basis_json"] or "[]")),
+        "evidence": evidence,
+    }
+
+
+def _json_dump(payload: Any) -> str:
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True)

--- a/src/indexer/cpp_function_graph_tree_sitter.py
+++ b/src/indexer/cpp_function_graph_tree_sitter.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from cpp_function_graph_model import FunctionAstExtract
+
+
+class TreeSitterUnavailableError(RuntimeError):
+    pass
+
+
+class TreeSitterCppFunctionBodyParser:
+    parser_id = "tree-sitter-cpp"
+    parser_version = "unavailable"
+
+    def __init__(self) -> None:
+        raise TreeSitterUnavailableError(
+            "Tree-sitter C++ is not configured for this project yet. "
+            "Use LightweightFunctionBodyParser for tests until the dependency is added."
+        )
+
+    def parse_function(
+        self,
+        *,
+        symbol_id: str,
+        source_fingerprint: str,
+        function_text: str,
+        base_line: int,
+        base_byte: int,
+    ) -> FunctionAstExtract:
+        raise TreeSitterUnavailableError("Tree-sitter C++ parser is not available.")

--- a/src/indexer/cpp_function_graph_visibility.py
+++ b/src/indexer/cpp_function_graph_visibility.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+from typing import Any
+
+from cpp_function_graph_model import FunctionAstExtract, FunctionSourceSlice, FunctionVisibilityContext
+from cpp_project_index import CODE_ENTITY_CALLABLE_SYMBOL_TYPES, CODE_ENTITY_TYPE_SYMBOL_TYPES
+
+
+VISIBILITY_CONTEXT_VERSION = "cpp-function-graph-visibility-v0.1"
+
+
+def build_function_visibility_context(
+    *,
+    index: Any,
+    source: FunctionSourceSlice,
+    ast_extract: FunctionAstExtract | None = None,
+) -> FunctionVisibilityContext:
+    function_symbol = _symbol_by_id(index, source.symbol_id)
+    file_symbols = _symbols_for_file(index, source.file_id)
+    file_data = _data_for_file(index, source.file_id)
+    current_class_name = _current_class_name(function_symbol)
+    current_namespace = _namespace_parts(function_symbol, current_class_name=current_class_name)
+    current_class_symbol = _find_current_class_symbol(file_symbols, current_class_name)
+    imported_modules = _module_names_for_file(index, source.file_id)
+    visible_exported_symbols = _visible_module_symbols(index, imported_modules, source.file_id)
+    member_data = _member_data(file_data, current_class_name)
+    using_declarations = _scope_items_for_file(index, "using_declarations", source.file_id, source.start_line)
+    using_directives = _scope_items_for_file(index, "using_directives", source.file_id, source.start_line)
+    namespace_aliases = _scope_items_for_file(index, "namespace_aliases", source.file_id, source.start_line)
+
+    return FunctionVisibilityContext(
+        file_id=source.file_id,
+        file_path=source.relative_path,
+        function_symbol_id=source.symbol_id,
+        current_namespace=tuple(current_namespace),
+        current_class_symbol_id=(
+            str(current_class_symbol.get("symbolId"))
+            if current_class_symbol is not None and current_class_symbol.get("symbolId") is not None
+            else None
+        ),
+        current_class_name=current_class_name,
+        imported_modules=tuple(imported_modules),
+        visible_exported_symbols=tuple(_compact_symbol(item) for item in visible_exported_symbols),
+        same_file_symbols=tuple(_compact_symbol(item) for item in file_symbols),
+        same_file_data=tuple(_compact_data(item) for item in file_data),
+        member_data=tuple(_compact_data(item) for item in member_data),
+        using_declarations=tuple(_compact_scope_item(item) for item in using_declarations),
+        using_directives=tuple(_compact_scope_item(item) for item in using_directives),
+        namespace_aliases=tuple(_compact_scope_item(item) for item in namespace_aliases),
+        local_declarations=tuple(ast_extract.local_declarations) if ast_extract is not None else (),
+    )
+
+
+def _symbol_by_id(index: Any, symbol_id: str) -> dict[str, Any]:
+    symbol = index.symbol_by_id.get(symbol_id)
+    return dict(symbol) if symbol is not None else {}
+
+
+def _symbols_for_file(index: Any, file_id: str) -> list[dict[str, Any]]:
+    if getattr(index, "uses_sqlite", False) and hasattr(index, "sqlite_symbols_for_file"):
+        return [dict(item) for item in index.sqlite_symbols_for_file(file_id)]
+
+    return [
+        dict(item)
+        for item in getattr(index, "symbols", [])
+        if item.get("fileId") == file_id
+    ]
+
+
+def _data_for_file(index: Any, file_id: str) -> list[dict[str, Any]]:
+    if getattr(index, "uses_sqlite", False) and hasattr(index, "sqlite_data_for_file"):
+        return [dict(item) for item in index.sqlite_data_for_file(file_id)]
+
+    return [
+        dict(item)
+        for item in getattr(index, "data", [])
+        if item.get("fileId") == file_id
+    ]
+
+
+def _current_class_name(function_symbol: dict[str, Any]) -> str | None:
+    container = str(function_symbol.get("container") or "")
+    if not container:
+        qualified_name = str(function_symbol.get("qualifiedName") or "")
+        if "::" not in qualified_name:
+            return None
+        container = qualified_name.rsplit("::", 1)[0]
+
+    return container or None
+
+
+def _namespace_parts(function_symbol: dict[str, Any], *, current_class_name: str | None) -> list[str]:
+    container = str(function_symbol.get("container") or "")
+    if not container and current_class_name:
+        container = current_class_name
+
+    if not container:
+        return []
+
+    parts = [part for part in container.split("::") if part]
+    if current_class_name and parts and container == current_class_name:
+        return parts[:-1]
+    return parts
+
+
+def _find_current_class_symbol(
+    file_symbols: list[dict[str, Any]],
+    current_class_name: str | None,
+) -> dict[str, Any] | None:
+    if not current_class_name:
+        return None
+
+    current_class_tail = current_class_name.rsplit("::", 1)[-1]
+    for symbol in file_symbols:
+        symbol_type = str(symbol.get("type") or "")
+        if symbol_type not in CODE_ENTITY_TYPE_SYMBOL_TYPES:
+            continue
+        qualified_name = str(symbol.get("qualifiedName") or symbol.get("shortName") or "")
+        short_name = str(symbol.get("shortName") or "")
+        if qualified_name == current_class_name or short_name == current_class_tail:
+            return symbol
+
+    return None
+
+
+def _module_names_for_file(index: Any, file_id: str) -> list[str]:
+    modules = getattr(index, "modules", {}) or {}
+    result = [
+        str(module_name)
+        for module_name, file_ids in modules.items()
+        if file_id in file_ids
+    ]
+    return sorted(result, key=str.casefold)
+
+
+def _visible_module_symbols(index: Any, module_names: list[str], current_file_id: str) -> list[dict[str, Any]]:
+    if not module_names:
+        return []
+
+    file_ids: set[str] = set()
+    modules = getattr(index, "modules", {}) or {}
+    for module_name in module_names:
+        file_ids.update(str(file_id) for file_id in modules.get(module_name, []))
+    file_ids.discard(current_file_id)
+
+    result: list[dict[str, Any]] = []
+    for file_id in sorted(file_ids):
+        result.extend(
+            symbol
+            for symbol in _symbols_for_file(index, file_id)
+            if str(symbol.get("type") or "") in CODE_ENTITY_CALLABLE_SYMBOL_TYPES | CODE_ENTITY_TYPE_SYMBOL_TYPES
+        )
+    return result
+
+
+def _member_data(file_data: list[dict[str, Any]], current_class_name: str | None) -> list[dict[str, Any]]:
+    if not current_class_name:
+        return []
+
+    current_class_folded = current_class_name.casefold()
+    current_class_tail = current_class_name.rsplit("::", 1)[-1].casefold()
+    result: list[dict[str, Any]] = []
+    for item in file_data:
+        container = str(item.get("container") or "")
+        if container.casefold() in {current_class_folded, current_class_tail} or container.casefold().endswith("::" + current_class_tail):
+            result.append(item)
+    return result
+
+
+def _scope_items_for_file(index: Any, attr_name: str, file_id: str, line: int) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for item in getattr(index, attr_name, []) or []:
+        if str(item.get("fileId") or "") != file_id:
+            continue
+        active_from = int(item.get("activeFromLine") or item.get("startLine") or 1)
+        active_to = int(item.get("activeToLine") or item.get("endLine") or 2**31 - 1)
+        if active_from <= line <= active_to:
+            result.append(dict(item))
+    return result
+
+
+def _compact_symbol(symbol: dict[str, Any]) -> dict[str, Any]:
+    fields = (
+        "symbolId",
+        "type",
+        "shortName",
+        "qualifiedName",
+        "container",
+        "relativePath",
+        "startLine",
+        "endLine",
+        "signature",
+    )
+    return {field: symbol.get(field) for field in fields if field in symbol}
+
+
+def _compact_data(item: dict[str, Any]) -> dict[str, Any]:
+    fields = (
+        "dataId",
+        "declarationKind",
+        "scopeKind",
+        "name",
+        "shortName",
+        "qualifiedName",
+        "container",
+        "typeText",
+        "relativePath",
+        "startLine",
+        "endLine",
+        "signature",
+    )
+    return {field: item.get(field) for field in fields if field in item}
+
+
+def _compact_scope_item(item: dict[str, Any]) -> dict[str, Any]:
+    fields = (
+        "name",
+        "target",
+        "targetName",
+        "namespace",
+        "alias",
+        "qualifiedName",
+        "fileId",
+        "relativePath",
+        "startLine",
+        "endLine",
+        "activeFromLine",
+        "activeToLine",
+    )
+    return {field: item.get(field) for field in fields if field in item}

--- a/src/server/code_index_mcp_server.py
+++ b/src/server/code_index_mcp_server.py
@@ -39,6 +39,12 @@ from cpp_index_lock import (
     index_http_server_lock,
     index_watcher_lock,
 )
+from cpp_function_graph_model import FunctionGraphRequest
+from cpp_function_graph_service import (
+    FunctionGraphSourceError,
+    FunctionGraphSourceService,
+    function_graph_result_to_api,
+)
 from cpp_project_index import LoadedProjectIndex, normalize_jobs
 from indexer_control import (
     fmt_bytes,
@@ -290,6 +296,10 @@ PACKABLE_TOOL_NAMES = {
     "get_file_fingerprint",
     "get_symbol_fingerprint",
     "get_data_fingerprint",
+    "get_function_body_graph",
+    "get_call_xrefs_from",
+    "get_call_xrefs_to",
+    "get_symbol_neighborhood",
     "validate_fingerprints",
     "get_project_orientation",
     "list_orientation_nodes",
@@ -373,6 +383,10 @@ CAPABILITY_CATEGORIES: dict[str, list[str]] = {
     "metadata": [
         "get_project_summary",
         "get_file_structure",
+        "get_function_body_graph",
+        "get_call_xrefs_from",
+        "get_call_xrefs_to",
+        "get_symbol_neighborhood",
         "list_file_symbols",
         "get_nearest_symbol_for_line",
     ],
@@ -433,6 +447,34 @@ CAPABILITY_TOOL_METADATA: dict[str, dict[str, Any]] = {
     "get_file_fingerprint": {"category": "fingerprint", "claimStrength": "metadata_only", "preFetchAllowed": True},
     "get_symbol_fingerprint": {"category": "fingerprint", "claimStrength": "metadata_only", "preFetchAllowed": True},
     "get_data_fingerprint": {"category": "fingerprint", "claimStrength": "metadata_only", "preFetchAllowed": True},
+    "get_function_body_graph": {
+        "category": "metadata",
+        "claimStrength": "source_structure_allowed",
+        "preFetchAllowed": False,
+        "evidenceKind": "function_body_graph",
+        "sourceBehaviorAllowed": False,
+    },
+    "get_call_xrefs_from": {
+        "category": "metadata",
+        "claimStrength": "source_structure_allowed",
+        "preFetchAllowed": False,
+        "evidenceKind": "function_graph_xrefs",
+        "sourceBehaviorAllowed": False,
+    },
+    "get_call_xrefs_to": {
+        "category": "metadata",
+        "claimStrength": "source_structure_allowed",
+        "preFetchAllowed": False,
+        "evidenceKind": "function_graph_xrefs",
+        "sourceBehaviorAllowed": False,
+    },
+    "get_symbol_neighborhood": {
+        "category": "metadata",
+        "claimStrength": "source_structure_allowed",
+        "preFetchAllowed": False,
+        "evidenceKind": "function_graph_neighborhood",
+        "sourceBehaviorAllowed": False,
+    },
     "validate_fingerprints": {"category": "fingerprint", "claimStrength": "metadata_only", "preFetchAllowed": True},
     "get_project_orientation": {
         "category": "orientation",
@@ -718,6 +760,134 @@ def tool_definitions(*, include_orientation: bool = True) -> list[dict[str, Any]
                     }
                 },
                 "required": ["dataId"],
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": "get_function_body_graph",
+            "description": (
+                "[FunctionGraph] Return on-demand direct function-body relation edges for one indexed C++ function. "
+                "This is structural navigation evidence only: claimStrength is source_structure_allowed and "
+                "behaviorClaimsAllowed is false. It may compute/cache parser and resolver output, but it does not "
+                "read arbitrary source ranges, resolve external APIs semantically, or support behavior claims."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "symbolId": {
+                        "type": "string",
+                        "description": "Callable symbol id returned by find_symbol/list_file_symbols.",
+                    },
+                    "mode": {
+                        "type": "string",
+                        "enum": ["cache_only", "compute_if_missing", "refresh"],
+                        "default": "compute_if_missing",
+                        "description": "cache_only never computes, compute_if_missing computes on miss, refresh recomputes.",
+                    },
+                    "includeControlFlow": {
+                        "type": "boolean",
+                        "default": True,
+                        "description": "Reserved structural filter for control-flow markers when exposed by the graph.",
+                    },
+                    "includeDataAccess": {
+                        "type": "boolean",
+                        "default": True,
+                        "description": "Reserved structural filter for data/member access edges when exposed by the graph.",
+                    },
+                    "includeExternal": {
+                        "type": "boolean",
+                        "default": True,
+                        "description": "Include calls marked external/unresolved outside the project symbol index.",
+                    },
+                    "maxEdges": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 1000,
+                        "default": 200,
+                    },
+                },
+                "required": ["symbolId"],
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": "get_call_xrefs_from",
+            "description": (
+                "[FunctionGraph] Return persisted outgoing call edges from one indexed symbol. "
+                "Reads only stored function graph edges; it does not compute missing graphs. "
+                "Structural navigation only: behaviorClaimsAllowed is false."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "symbolId": {
+                        "type": "string",
+                        "description": "Caller function symbol id.",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 1000,
+                        "default": 200,
+                    },
+                },
+                "required": ["symbolId"],
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": "get_call_xrefs_to",
+            "description": (
+                "[FunctionGraph] Return persisted incoming call edges to one indexed symbol. "
+                "Reads only stored function graph edges; callers appear after their function graphs have been computed. "
+                "Structural navigation only: behaviorClaimsAllowed is false."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "symbolId": {
+                        "type": "string",
+                        "description": "Target callee symbol id.",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 1000,
+                        "default": 200,
+                    },
+                },
+                "required": ["symbolId"],
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": "get_symbol_neighborhood",
+            "description": (
+                "[FunctionGraph] Return a compact persisted function graph neighborhood for one symbol: "
+                "target metadata, callers, callees, and incoming/outgoing edges. "
+                "Reads only stored edges and does not compute missing graphs. Structural navigation only."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "symbolId": {
+                        "type": "string",
+                        "description": "Target symbol id.",
+                    },
+                    "incomingLimit": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 1000,
+                        "default": 100,
+                    },
+                    "outgoingLimit": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 1000,
+                        "default": 100,
+                    },
+                },
+                "required": ["symbolId"],
                 "additionalProperties": False,
             },
         },
@@ -3026,6 +3196,172 @@ class CodeIndexTools:
         data_id = require_string(arguments, "dataId")
         return self.json_result(arguments, self.data_fingerprint_payload(data_id))
 
+    def function_graph_symbol_index_fingerprint(
+        self,
+        *,
+        symbol_id: str,
+        symbol_fingerprint: dict[str, Any],
+    ) -> str:
+        symbol = self.index.symbol_by_id.get(symbol_id) or {}
+        file_id = str(symbol.get("fileId") or "")
+        return stable_hash_payload(
+            {
+                "kind": "function_graph_symbol_index",
+                "schema": self.index.manifest.get("schema"),
+                "createdAt": self.index.manifest.get("createdUtc") or self.index.manifest.get("createdAt"),
+                "symbolCount": len(getattr(self.index, "symbols", [])),
+                "dataCount": len(getattr(self.index, "data", [])),
+                "fileCount": len(getattr(self.index, "files", [])),
+                "symbolId": symbol_id,
+                "symbolFingerprint": symbol_fingerprint.get("fingerprint"),
+                "fileId": file_id,
+            }
+        )
+
+    def function_graph_module_visibility_fingerprint(self, *, symbol_id: str) -> str:
+        symbol = self.index.symbol_by_id.get(symbol_id) or {}
+        file_id = str(symbol.get("fileId") or "")
+        file_item = self.index.file_by_id.get(file_id) or {}
+        return stable_hash_payload(
+            {
+                "kind": "function_graph_module_visibility",
+                "schema": self.index.manifest.get("schema"),
+                "symbolId": symbol_id,
+                "fileId": file_id,
+                "relativePath": file_item.get("relativePath"),
+                "modules": getattr(self.index, "modules", {}),
+            }
+        )
+
+    def get_function_body_graph(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        symbol_id = require_string(arguments, "symbolId")
+        mode = arguments.get("mode", "compute_if_missing")
+
+        if mode not in {"cache_only", "compute_if_missing", "refresh"}:
+            raise McpError(-32602, "mode must be cache_only, compute_if_missing, or refresh")
+
+        include_control_flow = optional_bool(arguments, "includeControlFlow", True)
+        include_data_access = optional_bool(arguments, "includeDataAccess", True)
+        include_external = optional_bool(arguments, "includeExternal", True)
+        max_edges = clamp_int(arguments.get("maxEdges", 200), minimum=0, maximum=1000)
+        symbol_fingerprint = self.symbol_fingerprint_payload(symbol_id)
+
+        if not symbol_fingerprint.get("valid"):
+            return self.json_result(
+                arguments,
+                {
+                    "code": "symbol_not_found",
+                    "message": f"Symbol {symbol_id!r} was not found in the loaded index.",
+                    "symbolId": symbol_id,
+                },
+                is_error=True,
+            )
+
+        request = FunctionGraphRequest(
+            symbol_id=symbol_id,
+            mode=mode,
+            include_control_flow=include_control_flow,
+            include_data_access=include_data_access,
+            include_external=include_external,
+            max_edges=max_edges,
+        )
+        service = FunctionGraphSourceService(
+            project_root=self.project_root,
+            index=self.index,
+            index_root=self.index_root,
+        )
+
+        try:
+            result = service.get_function_body_graph(
+                request,
+                file_fingerprint=str(symbol_fingerprint.get("fileFingerprint") or ""),
+                symbol_index_fingerprint=self.function_graph_symbol_index_fingerprint(
+                    symbol_id=symbol_id,
+                    symbol_fingerprint=symbol_fingerprint,
+                ),
+                module_visibility_fingerprint=self.function_graph_module_visibility_fingerprint(
+                    symbol_id=symbol_id,
+                ),
+            )
+        except FunctionGraphSourceError as exc:
+            return self.json_result(arguments, exc.to_dict(), is_error=True)
+
+        payload = function_graph_result_to_api(result)
+        payload["request"] = {
+            "mode": mode,
+            "includeControlFlow": include_control_flow,
+            "includeDataAccess": include_data_access,
+            "includeExternal": include_external,
+            "maxEdges": max_edges,
+        }
+        return self.json_result(arguments, payload)
+
+    def get_call_xrefs_from(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        symbol_id = require_string(arguments, "symbolId")
+        limit = clamp_int(arguments.get("limit", 200), minimum=0, maximum=1000)
+        service = FunctionGraphSourceService(
+            project_root=self.project_root,
+            index=self.index,
+            index_root=self.index_root,
+        )
+
+        try:
+            result = service.get_call_xrefs_from(symbol_id, limit=limit)
+        except FunctionGraphSourceError as exc:
+            return self.json_result(arguments, exc.to_dict(), is_error=True)
+
+        result["request"] = {
+            "symbolId": symbol_id,
+            "limit": limit,
+        }
+        return self.json_result(arguments, result)
+
+    def get_call_xrefs_to(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        symbol_id = require_string(arguments, "symbolId")
+        limit = clamp_int(arguments.get("limit", 200), minimum=0, maximum=1000)
+        service = FunctionGraphSourceService(
+            project_root=self.project_root,
+            index=self.index,
+            index_root=self.index_root,
+        )
+
+        try:
+            result = service.get_call_xrefs_to(symbol_id, limit=limit)
+        except FunctionGraphSourceError as exc:
+            return self.json_result(arguments, exc.to_dict(), is_error=True)
+
+        result["request"] = {
+            "symbolId": symbol_id,
+            "limit": limit,
+        }
+        return self.json_result(arguments, result)
+
+    def get_symbol_neighborhood(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        symbol_id = require_string(arguments, "symbolId")
+        incoming_limit = clamp_int(arguments.get("incomingLimit", 100), minimum=0, maximum=1000)
+        outgoing_limit = clamp_int(arguments.get("outgoingLimit", 100), minimum=0, maximum=1000)
+        service = FunctionGraphSourceService(
+            project_root=self.project_root,
+            index=self.index,
+            index_root=self.index_root,
+        )
+
+        try:
+            result = service.get_symbol_neighborhood(
+                symbol_id,
+                incoming_limit=incoming_limit,
+                outgoing_limit=outgoing_limit,
+            )
+        except FunctionGraphSourceError as exc:
+            return self.json_result(arguments, exc.to_dict(), is_error=True)
+
+        result["request"] = {
+            "symbolId": symbol_id,
+            "incomingLimit": incoming_limit,
+            "outgoingLimit": outgoing_limit,
+        }
+        return self.json_result(arguments, result)
+
     def validate_fingerprints(self, arguments: dict[str, Any]) -> dict[str, Any]:
         items = arguments.get("items")
 
@@ -4602,6 +4938,10 @@ class McpServer:
             "get_file_fingerprint": self.tools.get_file_fingerprint,
             "get_symbol_fingerprint": self.tools.get_symbol_fingerprint,
             "get_data_fingerprint": self.tools.get_data_fingerprint,
+            "get_function_body_graph": self.tools.get_function_body_graph,
+            "get_call_xrefs_from": self.tools.get_call_xrefs_from,
+            "get_call_xrefs_to": self.tools.get_call_xrefs_to,
+            "get_symbol_neighborhood": self.tools.get_symbol_neighborhood,
             "validate_fingerprints": self.tools.validate_fingerprints,
             "get_project_orientation": self.tools.get_project_orientation,
             "list_orientation_nodes": self.tools.list_orientation_nodes,

--- a/tests/test_cpp_function_graph_extract.py
+++ b/tests/test_cpp_function_graph_extract.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import sys
+import unittest
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INDEXER_SRC = REPO_ROOT / "src" / "indexer"
+if str(INDEXER_SRC) not in sys.path:
+    sys.path.insert(0, str(INDEXER_SRC))
+
+from cpp_function_graph_extract import LightweightFunctionBodyParser, extract_raw_function_ast
+from cpp_function_graph_tree_sitter import TreeSitterCppFunctionBodyParser, TreeSitterUnavailableError
+
+
+class FunctionGraphRawExtractionTests(unittest.TestCase):
+    def test_extracts_calls_member_access_locals_and_control_flow(self) -> None:
+        function_text = "\n".join(
+            [
+                "void Paint()",
+                "{",
+                "    auto opacity = _CalculatePulseOpacity();",
+                "    NS::Draw(opacity, _OverlayPosition);",
+                "    this->_State.Reset();",
+                "    _OverlayPosition = opacity;",
+                "    if (_OverlayPosition > 0) {",
+                "        return;",
+                "    }",
+                "}",
+            ]
+        )
+
+        extract = extract_raw_function_ast(
+            symbol_id="fn-paint",
+            source_fingerprint="sha256:source",
+            function_text=function_text,
+            base_line=40,
+            base_byte=120,
+        )
+
+        calls = {item["callee"]: item for item in extract.calls}
+        self.assertEqual(calls["_CalculatePulseOpacity"]["callKind"], "unqualified")
+        self.assertEqual(calls["NS::Draw"]["callKind"], "qualified")
+        self.assertEqual(calls["NS::Draw"]["argumentCount"], 2)
+        self.assertEqual(calls["this->_State.Reset"]["callKind"], "member")
+
+        writes = [
+            item
+            for item in extract.member_accesses
+            if item["text"] == "_OverlayPosition" and item["accessKind"] == "write_candidate"
+        ]
+        self.assertEqual(len(writes), 1)
+        self.assertEqual(writes[0]["line"], 45)
+
+        locals_by_name = {item["name"]: item for item in extract.local_declarations}
+        self.assertEqual(locals_by_name["opacity"]["typeText"], "auto")
+        self.assertEqual(locals_by_name["opacity"]["line"], 42)
+
+        markers = [(item["marker"], item["line"]) for item in extract.control_flow]
+        self.assertIn(("if", 46), markers)
+        self.assertIn(("return", 47), markers)
+
+    def test_parser_adapter_delegates_to_raw_extractor(self) -> None:
+        parser = LightweightFunctionBodyParser()
+
+        extract = parser.parse_function(
+            symbol_id="fn",
+            source_fingerprint="sha256:source",
+            function_text="void f()\n{\n    foo();\n}\n",
+            base_line=10,
+            base_byte=200,
+        )
+
+        self.assertEqual(extract.parser_id, parser.parser_id)
+        self.assertEqual(extract.parser_version, parser.parser_version)
+        self.assertEqual(extract.calls[0]["callee"], "foo")
+        self.assertEqual(extract.calls[0]["line"], 12)
+
+    def test_tree_sitter_adapter_is_isolated_until_dependency_exists(self) -> None:
+        with self.assertRaises(TreeSitterUnavailableError):
+            TreeSitterCppFunctionBodyParser()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cpp_function_graph_mcp_schema.py
+++ b/tests/test_cpp_function_graph_mcp_schema.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import sys
+import unittest
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SERVER_SRC = REPO_ROOT / "src" / "server"
+INDEXER_SRC = REPO_ROOT / "src" / "indexer"
+for support_path in (SERVER_SRC, INDEXER_SRC):
+    if str(support_path) not in sys.path:
+        sys.path.insert(0, str(support_path))
+
+import code_index_mcp_server as server
+
+
+class FunctionGraphMcpSchemaTests(unittest.TestCase):
+    def test_get_function_body_graph_schema_is_registered_and_packable(self) -> None:
+        tools = {
+            item["name"]: item
+            for item in server.tool_definitions(include_orientation=False)
+        }
+
+        self.assertIn("get_function_body_graph", tools)
+        self.assertIn("get_function_body_graph", server.PACKABLE_TOOL_NAMES)
+        self.assertEqual(
+            server.CAPABILITY_TOOL_METADATA["get_function_body_graph"]["claimStrength"],
+            "source_structure_allowed",
+        )
+        self.assertFalse(
+            server.CAPABILITY_TOOL_METADATA["get_function_body_graph"]["sourceBehaviorAllowed"]
+        )
+
+        schema = tools["get_function_body_graph"]["inputSchema"]
+        self.assertEqual(schema["required"], ["symbolId"])
+        self.assertEqual(
+            schema["properties"]["mode"]["enum"],
+            ["cache_only", "compute_if_missing", "refresh"],
+        )
+        self.assertIn("responseFormat", schema["properties"])
+        self.assertEqual(schema["properties"]["maxEdges"]["maximum"], 1000)
+
+    def test_xref_and_neighborhood_schemas_are_registered_and_structural(self) -> None:
+        tools = {
+            item["name"]: item
+            for item in server.tool_definitions(include_orientation=False)
+        }
+
+        for tool_name in ("get_call_xrefs_from", "get_call_xrefs_to", "get_symbol_neighborhood"):
+            with self.subTest(tool_name=tool_name):
+                self.assertIn(tool_name, tools)
+                self.assertIn(tool_name, server.PACKABLE_TOOL_NAMES)
+                self.assertEqual(
+                    server.CAPABILITY_TOOL_METADATA[tool_name]["claimStrength"],
+                    "source_structure_allowed",
+                )
+                self.assertFalse(
+                    server.CAPABILITY_TOOL_METADATA[tool_name]["sourceBehaviorAllowed"]
+                )
+                schema = tools[tool_name]["inputSchema"]
+                self.assertEqual(schema["required"], ["symbolId"])
+                self.assertIn("responseFormat", schema["properties"])
+
+        self.assertEqual(
+            tools["get_call_xrefs_from"]["inputSchema"]["properties"]["limit"]["maximum"],
+            1000,
+        )
+        self.assertEqual(
+            tools["get_symbol_neighborhood"]["inputSchema"]["properties"]["incomingLimit"]["default"],
+            100,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cpp_function_graph_mcp_smoke.py
+++ b/tests/test_cpp_function_graph_mcp_smoke.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SERVER_SRC = REPO_ROOT / "src" / "server"
+INDEXER_SRC = REPO_ROOT / "src" / "indexer"
+for support_path in (SERVER_SRC, INDEXER_SRC):
+    if str(support_path) not in sys.path:
+        sys.path.insert(0, str(support_path))
+
+from code_index_mcp_server import CodeIndexTools
+
+
+class FunctionGraphMcpSmokeTests(unittest.TestCase):
+    def test_real_index_tool_path_computes_cache_xrefs_and_structural_edges(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            project_root = Path(temp_dir)
+            index_root = project_root / ".mcp-cpp-project-indexer"
+            (project_root / "sample.cpp").write_text(
+                "\n".join(
+                    [
+                        "namespace App {",
+                        "void Helper();",
+                        "class Painter {",
+                        "    int _OverlayPosition;",
+                        "    void Paint();",
+                        "};",
+                        "void Painter::Paint()",
+                        "{",
+                        "    Helper();",
+                        "    if (_OverlayPosition > 0) {",
+                        "        _OverlayPosition = 1;",
+                        "    }",
+                        "    SendMessageW();",
+                        "}",
+                        "void Helper()",
+                        "{",
+                        "}",
+                        "}",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "build_project_index.py"),
+                    "--root",
+                    str(project_root),
+                    "--output-root",
+                    str(index_root),
+                    "--jobs",
+                    "1",
+                    "--no-progress",
+                    "--print-summary-json",
+                ],
+                cwd=REPO_ROOT,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            tools = CodeIndexTools(project_root=project_root, index_root=index_root)
+            try:
+                paint_symbol_id = self._definition_symbol_id(tools, "Paint")
+
+                graph = self._call_json(
+                    tools.get_function_body_graph(
+                        {
+                            "symbolId": paint_symbol_id,
+                            "mode": "compute_if_missing",
+                            "responseFormat": "minified",
+                        }
+                    )
+                )
+                cache_only = self._call_json(
+                    tools.get_function_body_graph(
+                        {
+                            "symbolId": paint_symbol_id,
+                            "mode": "cache_only",
+                            "responseFormat": "minified",
+                        }
+                    )
+                )
+                xrefs = self._call_json(
+                    tools.get_call_xrefs_from(
+                        {
+                            "symbolId": paint_symbol_id,
+                            "responseFormat": "minified",
+                        }
+                    )
+                )
+                filtered = self._call_json(
+                    tools.get_function_body_graph(
+                        {
+                            "symbolId": paint_symbol_id,
+                            "mode": "refresh",
+                            "includeDataAccess": False,
+                            "includeControlFlow": False,
+                            "responseFormat": "minified",
+                        }
+                    )
+                )
+            finally:
+                tools.index.close_sqlite_connections()
+
+        edge_statuses = {edge["toText"]: edge["resolutionStatus"] for edge in graph["edges"]}
+        edge_kinds = {edge["edgeKind"] for edge in graph["edges"]}
+        filtered_edge_kinds = {edge["edgeKind"] for edge in filtered["edges"]}
+
+        self.assertEqual(graph["schema"], "cpp.function_body_graph.v0.1")
+        self.assertEqual(graph["status"], "computed")
+        self.assertFalse(graph["fromCache"])
+        self.assertFalse(graph["behaviorClaimsAllowed"])
+        self.assertIn(edge_statuses["Helper"], {"exact", "probable", "ambiguous"})
+        self.assertEqual(edge_statuses["SendMessageW"], "external")
+        self.assertIn("reads_data_candidate", edge_kinds)
+        self.assertIn("writes_data_candidate", edge_kinds)
+        self.assertIn("control_flow_marker", edge_kinds)
+        self.assertTrue(cache_only["fromCache"])
+        self.assertEqual(cache_only["fingerprints"]["graph"], graph["fingerprints"]["graph"])
+        self.assertGreaterEqual(xrefs["returnedEdges"], 3)
+        self.assertFalse(xrefs["behaviorClaimsAllowed"])
+        self.assertNotIn("reads_data_candidate", filtered_edge_kinds)
+        self.assertNotIn("writes_data_candidate", filtered_edge_kinds)
+        self.assertNotIn("control_flow_marker", filtered_edge_kinds)
+        self.assertFalse(filtered["behaviorClaimsAllowed"])
+
+    def _definition_symbol_id(self, tools: CodeIndexTools, query: str) -> str:
+        results = self._call_json(
+            tools.find_symbol(
+                {
+                    "query": query,
+                    "exactOnly": True,
+                    "responseFormat": "minified",
+                }
+            )
+        )
+        for item in results:
+            if item.get("type") == "function" and int(item.get("endLine") or 0) > int(item.get("startLine") or 0):
+                return str(item["symbolId"])
+        self.fail(f"Definition symbol not found for {query!r}")
+
+    def _call_json(self, result: dict[str, Any]) -> Any:
+        self.assertFalse(result.get("isError"), result)
+        return json.loads(str(result["content"][0]["text"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cpp_function_graph_resolver.py
+++ b/tests/test_cpp_function_graph_resolver.py
@@ -390,6 +390,88 @@ class FunctionGraphResolverTests(unittest.TestCase):
         self.assertEqual(edges[0].to_symbol_id, "fn-renderer-draw")
         self.assertIn("local_type_hint", edges[0].basis)
 
+    def test_data_access_and_control_flow_markers_are_structural_edges(self) -> None:
+        visibility = FunctionVisibilityContext(
+            file_id="file-1",
+            file_path="paint.cpp",
+            function_symbol_id="fn-paint",
+            current_namespace=("App",),
+            current_class_symbol_id="cls-1",
+            current_class_name="App::Painter",
+            imported_modules=(),
+            visible_exported_symbols=(),
+            same_file_symbols=(),
+            same_file_data=(),
+            member_data=(
+                {
+                    "dataId": "data-overlay",
+                    "name": "_OverlayPosition",
+                    "shortName": "_OverlayPosition",
+                    "qualifiedName": "App::Painter::_OverlayPosition",
+                    "container": "App::Painter",
+                    "typeText": "int",
+                },
+            ),
+        )
+        ast = FunctionAstExtract(
+            symbol_id="fn-paint",
+            source_fingerprint="sha256:source",
+            parser_id="fixture",
+            parser_version="v1",
+            extractor_version="v1",
+            member_accesses=(
+                {
+                    "text": "_OverlayPosition",
+                    "accessKind": "write_candidate",
+                },
+            ),
+            control_flow=(
+                {
+                    "marker": "if",
+                },
+            ),
+        )
+
+        edges = resolve_function_graph_edges(ast_extract=ast, visibility=visibility)
+
+        self.assertEqual([edge.edge_kind for edge in edges], ["writes_data_candidate", "control_flow_marker"])
+        self.assertEqual(edges[0].resolution_status, "probable")
+        self.assertEqual(edges[0].candidates[0]["dataId"], "data-overlay")
+        self.assertIn("indexed_member_data", edges[0].basis)
+        self.assertEqual(edges[1].resolution_status, "exact")
+        self.assertEqual(edges[1].to_text, "if")
+        self.assertFalse(edges[1].behavior_claims_allowed)
+
+    def test_data_and_control_flow_edges_can_be_disabled(self) -> None:
+        visibility = visibility_with_symbols()
+        ast = FunctionAstExtract(
+            symbol_id="fn-paint",
+            source_fingerprint="sha256:source",
+            parser_id="fixture",
+            parser_version="v1",
+            extractor_version="v1",
+            member_accesses=(
+                {
+                    "text": "_OverlayPosition",
+                    "accessKind": "read_candidate",
+                },
+            ),
+            control_flow=(
+                {
+                    "marker": "return",
+                },
+            ),
+        )
+
+        edges = resolve_function_graph_edges(
+            ast_extract=ast,
+            visibility=visibility,
+            include_data_access=False,
+            include_control_flow=False,
+        )
+
+        self.assertEqual(edges, ())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cpp_function_graph_resolver.py
+++ b/tests/test_cpp_function_graph_resolver.py
@@ -1,0 +1,395 @@
+from __future__ import annotations
+
+import sys
+import unittest
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INDEXER_SRC = REPO_ROOT / "src" / "indexer"
+if str(INDEXER_SRC) not in sys.path:
+    sys.path.insert(0, str(INDEXER_SRC))
+
+from cpp_function_graph_model import FunctionAstExtract, FunctionVisibilityContext
+from cpp_function_graph_resolver import resolve_function_graph_edges
+
+
+def visibility_with_symbols(*symbols: dict) -> FunctionVisibilityContext:
+    return FunctionVisibilityContext(
+        file_id="file-1",
+        file_path="paint.cpp",
+        function_symbol_id="fn-paint",
+        current_namespace=("App",),
+        current_class_symbol_id="cls-1",
+        current_class_name="App::Painter",
+        imported_modules=("App.Core",),
+        visible_exported_symbols=(),
+        same_file_symbols=tuple(symbols),
+        same_file_data=(),
+        member_data=(),
+    )
+
+
+class FunctionGraphResolverTests(unittest.TestCase):
+    def test_resolves_this_member_against_current_class(self) -> None:
+        visibility = visibility_with_symbols(
+            {
+                "symbolId": "fn-reset",
+                "type": "method",
+                "shortName": "Reset",
+                "qualifiedName": "App::Painter::Reset",
+                "container": "App::Painter",
+            }
+        )
+        ast = FunctionAstExtract(
+            symbol_id="fn-paint",
+            source_fingerprint="sha256:source",
+            parser_id="fixture",
+            parser_version="v1",
+            extractor_version="v1",
+            calls=(
+                {
+                    "callee": "this->Reset",
+                    "callKind": "member",
+                },
+            ),
+        )
+
+        edges = resolve_function_graph_edges(ast_extract=ast, visibility=visibility)
+
+        self.assertEqual(len(edges), 1)
+        self.assertEqual(edges[0].edge_kind, "calls_resolved")
+        self.assertEqual(edges[0].resolution_status, "exact")
+        self.assertEqual(edges[0].to_symbol_id, "fn-reset")
+        self.assertIn("current_class", edges[0].basis)
+
+    def test_resolves_same_file_namespace_function_as_probable_candidate(self) -> None:
+        visibility = visibility_with_symbols(
+            {
+                "symbolId": "fn-helper",
+                "type": "function",
+                "shortName": "Helper",
+                "qualifiedName": "App::Helper",
+                "container": "App",
+            }
+        )
+        ast = FunctionAstExtract(
+            symbol_id="fn-paint",
+            source_fingerprint="sha256:source",
+            parser_id="fixture",
+            parser_version="v1",
+            extractor_version="v1",
+            calls=(
+                {
+                    "callee": "Helper",
+                    "callKind": "unqualified",
+                },
+            ),
+        )
+
+        edges = resolve_function_graph_edges(ast_extract=ast, visibility=visibility)
+
+        self.assertEqual(edges[0].edge_kind, "calls_candidate")
+        self.assertEqual(edges[0].resolution_status, "probable")
+        self.assertEqual(edges[0].to_symbol_id, "fn-helper")
+        self.assertIn("same_namespace", edges[0].basis)
+
+    def test_ambiguous_overload_returns_candidate_set(self) -> None:
+        visibility = visibility_with_symbols(
+            {
+                "symbolId": "fn-draw-1",
+                "type": "function",
+                "shortName": "Draw",
+                "qualifiedName": "App::Draw(int)",
+                "container": "App",
+            },
+            {
+                "symbolId": "fn-draw-2",
+                "type": "function",
+                "shortName": "Draw",
+                "qualifiedName": "App::Draw(float)",
+                "container": "App",
+            },
+        )
+        ast = FunctionAstExtract(
+            symbol_id="fn-paint",
+            source_fingerprint="sha256:source",
+            parser_id="fixture",
+            parser_version="v1",
+            extractor_version="v1",
+            calls=(
+                {
+                    "callee": "Draw",
+                    "callKind": "unqualified",
+                },
+            ),
+        )
+
+        edges = resolve_function_graph_edges(ast_extract=ast, visibility=visibility)
+
+        self.assertEqual(edges[0].edge_kind, "calls_ambiguous")
+        self.assertEqual(edges[0].resolution_status, "ambiguous")
+        self.assertIsNone(edges[0].to_symbol_id)
+        self.assertEqual({item["symbolId"] for item in edges[0].candidates}, {"fn-draw-1", "fn-draw-2"})
+
+    def test_qualified_call_resolves_exact_project_symbol(self) -> None:
+        visibility = visibility_with_symbols(
+            {
+                "symbolId": "fn-draw",
+                "type": "function",
+                "shortName": "Draw",
+                "qualifiedName": "App::Draw",
+                "container": "App",
+            }
+        )
+        ast = FunctionAstExtract(
+            symbol_id="fn-paint",
+            source_fingerprint="sha256:source",
+            parser_id="fixture",
+            parser_version="v1",
+            extractor_version="v1",
+            calls=(
+                {
+                    "callee": "App::Draw",
+                    "callKind": "qualified",
+                },
+            ),
+        )
+
+        edges = resolve_function_graph_edges(ast_extract=ast, visibility=visibility)
+
+        self.assertEqual(edges[0].resolution_status, "exact")
+        self.assertEqual(edges[0].to_symbol_id, "fn-draw")
+
+    def test_external_call_is_marked_external(self) -> None:
+        visibility = visibility_with_symbols()
+        ast = FunctionAstExtract(
+            symbol_id="fn-paint",
+            source_fingerprint="sha256:source",
+            parser_id="fixture",
+            parser_version="v1",
+            extractor_version="v1",
+            calls=(
+                {
+                    "callee": "SendMessageW",
+                    "callKind": "unqualified",
+                },
+            ),
+        )
+
+        edges = resolve_function_graph_edges(ast_extract=ast, visibility=visibility)
+
+        self.assertEqual(edges[0].edge_kind, "calls_external")
+        self.assertEqual(edges[0].resolution_status, "external")
+        self.assertIsNone(edges[0].to_symbol_id)
+        self.assertEqual(edges[0].basis, ("not_in_project_symbol_index",))
+
+    def test_using_namespace_adds_ambiguous_candidate_scope(self) -> None:
+        visibility = FunctionVisibilityContext(
+            file_id="file-1",
+            file_path="paint.cpp",
+            function_symbol_id="fn-paint",
+            current_namespace=("App",),
+            current_class_symbol_id=None,
+            current_class_name=None,
+            imported_modules=(),
+            visible_exported_symbols=(),
+            same_file_symbols=(
+                {
+                    "symbolId": "fn-theme-draw",
+                    "type": "function",
+                    "shortName": "Draw",
+                    "qualifiedName": "Theme::Draw",
+                    "container": "Theme",
+                    "signature": "void Draw(int)",
+                },
+                {
+                    "symbolId": "fn-legacy-draw",
+                    "type": "function",
+                    "shortName": "Draw",
+                    "qualifiedName": "Legacy::Draw",
+                    "container": "Legacy",
+                    "signature": "void Draw(int)",
+                },
+            ),
+            same_file_data=(),
+            member_data=(),
+            using_directives=(
+                {
+                    "namespace": "Theme",
+                },
+                {
+                    "namespace": "Legacy",
+                },
+            ),
+        )
+        ast = FunctionAstExtract(
+            symbol_id="fn-paint",
+            source_fingerprint="sha256:source",
+            parser_id="fixture",
+            parser_version="v1",
+            extractor_version="v1",
+            calls=(
+                {
+                    "callee": "Draw",
+                    "callKind": "unqualified",
+                    "argumentCount": 1,
+                },
+            ),
+        )
+
+        edges = resolve_function_graph_edges(ast_extract=ast, visibility=visibility)
+
+        self.assertEqual(edges[0].edge_kind, "calls_ambiguous")
+        self.assertEqual(edges[0].resolution_status, "ambiguous")
+        self.assertIn("using_namespace", edges[0].basis)
+        self.assertEqual({item["symbolId"] for item in edges[0].candidates}, {"fn-theme-draw", "fn-legacy-draw"})
+        self.assertTrue(all("arity_match" in item["basis"] for item in edges[0].candidates))
+
+    def test_namespace_alias_expands_qualified_name(self) -> None:
+        visibility = FunctionVisibilityContext(
+            file_id="file-1",
+            file_path="paint.cpp",
+            function_symbol_id="fn-paint",
+            current_namespace=("App",),
+            current_class_symbol_id=None,
+            current_class_name=None,
+            imported_modules=(),
+            visible_exported_symbols=(),
+            same_file_symbols=(
+                {
+                    "symbolId": "fn-themed-draw",
+                    "type": "function",
+                    "shortName": "Draw",
+                    "qualifiedName": "App::Theme::Draw",
+                    "container": "App::Theme",
+                    "signature": "void Draw()",
+                },
+            ),
+            same_file_data=(),
+            member_data=(),
+            namespace_aliases=(
+                {
+                    "alias": "Theme",
+                    "target": "App::Theme",
+                },
+            ),
+        )
+        ast = FunctionAstExtract(
+            symbol_id="fn-paint",
+            source_fingerprint="sha256:source",
+            parser_id="fixture",
+            parser_version="v1",
+            extractor_version="v1",
+            calls=(
+                {
+                    "callee": "Theme::Draw",
+                    "callKind": "qualified",
+                    "argumentCount": 0,
+                },
+            ),
+        )
+
+        edges = resolve_function_graph_edges(ast_extract=ast, visibility=visibility)
+
+        self.assertEqual(edges[0].resolution_status, "exact")
+        self.assertEqual(edges[0].to_symbol_id, "fn-themed-draw")
+        self.assertIn("namespace_alias", edges[0].basis)
+
+    def test_overload_scoring_prefers_arity_without_fake_exact_match(self) -> None:
+        visibility = visibility_with_symbols(
+            {
+                "symbolId": "fn-draw-1",
+                "type": "function",
+                "shortName": "Draw",
+                "qualifiedName": "App::Draw(int)",
+                "container": "App",
+                "signature": "void Draw(int value)",
+            },
+            {
+                "symbolId": "fn-draw-2",
+                "type": "function",
+                "shortName": "Draw",
+                "qualifiedName": "App::Draw(int, int)",
+                "container": "App",
+                "signature": "void Draw(int lhs, int rhs)",
+            },
+        )
+        ast = FunctionAstExtract(
+            symbol_id="fn-paint",
+            source_fingerprint="sha256:source",
+            parser_id="fixture",
+            parser_version="v1",
+            extractor_version="v1",
+            calls=(
+                {
+                    "callee": "Draw",
+                    "callKind": "unqualified",
+                    "argumentCount": 2,
+                },
+            ),
+        )
+
+        edges = resolve_function_graph_edges(ast_extract=ast, visibility=visibility)
+
+        self.assertEqual(edges[0].resolution_status, "ambiguous")
+        self.assertIsNone(edges[0].to_symbol_id)
+        self.assertEqual(edges[0].candidates[0]["symbolId"], "fn-draw-2")
+        self.assertGreater(edges[0].candidates[0]["score"], edges[0].candidates[1]["score"])
+        self.assertIn("arity_match", edges[0].candidates[0]["basis"])
+
+    def test_member_call_uses_local_type_hint_as_probable_candidate(self) -> None:
+        visibility = FunctionVisibilityContext(
+            file_id="file-1",
+            file_path="paint.cpp",
+            function_symbol_id="fn-paint",
+            current_namespace=("App",),
+            current_class_symbol_id=None,
+            current_class_name=None,
+            imported_modules=(),
+            visible_exported_symbols=(),
+            same_file_symbols=(
+                {
+                    "symbolId": "fn-renderer-draw",
+                    "type": "method",
+                    "shortName": "Draw",
+                    "qualifiedName": "App::Renderer::Draw",
+                    "container": "App::Renderer",
+                    "signature": "void Draw()",
+                },
+            ),
+            same_file_data=(),
+            member_data=(),
+            local_declarations=(
+                {
+                    "name": "renderer",
+                    "typeText": "App::Renderer",
+                },
+            ),
+        )
+        ast = FunctionAstExtract(
+            symbol_id="fn-paint",
+            source_fingerprint="sha256:source",
+            parser_id="fixture",
+            parser_version="v1",
+            extractor_version="v1",
+            calls=(
+                {
+                    "callee": "renderer.Draw",
+                    "callKind": "member",
+                    "argumentCount": 0,
+                },
+            ),
+        )
+
+        edges = resolve_function_graph_edges(ast_extract=ast, visibility=visibility)
+
+        self.assertEqual(edges[0].edge_kind, "calls_candidate")
+        self.assertEqual(edges[0].resolution_status, "probable")
+        self.assertEqual(edges[0].to_symbol_id, "fn-renderer-draw")
+        self.assertIn("local_type_hint", edges[0].basis)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cpp_function_graph_source.py
+++ b/tests/test_cpp_function_graph_source.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import sys
+import unittest
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INDEXER_SRC = REPO_ROOT / "src" / "indexer"
+if str(INDEXER_SRC) not in sys.path:
+    sys.path.insert(0, str(INDEXER_SRC))
+
+from cpp_function_graph_model import (
+    BEHAVIOR_CLAIMS_ALLOWED,
+    FUNCTION_GRAPH_SCHEMA,
+    SOURCE_STRUCTURE_CLAIM_STRENGTH,
+    FunctionGraphRequest,
+)
+from cpp_function_graph_service import FunctionGraphSourceError, FunctionGraphSourceService, text_fingerprint
+
+
+class FakeIndex:
+    def __init__(self) -> None:
+        self.uses_sqlite = False
+        self.file_by_id = {
+            "file-1": {
+                "fileId": "file-1",
+                "relativePath": "sample.cpp",
+            }
+        }
+        self.symbols = [
+            {
+                "symbolId": "fn-1",
+                "fileId": "file-1",
+                "type": "function",
+                "shortName": "add",
+                "qualifiedName": "add",
+                "startLine": 3,
+                "endLine": 6,
+                "signature": "int add(int lhs, int rhs)",
+            },
+            {
+                "symbolId": "class-1",
+                "fileId": "file-1",
+                "type": "class",
+                "shortName": "Thing",
+                "qualifiedName": "Thing",
+                "startLine": 1,
+                "endLine": 1,
+                "signature": "class Thing",
+            },
+            {
+                "symbolId": "fn-helper",
+                "fileId": "file-1",
+                "type": "function",
+                "shortName": "Helper",
+                "qualifiedName": "Helper",
+                "startLine": 8,
+                "endLine": 8,
+                "signature": "void Helper()",
+            },
+            {
+                "symbolId": "fn-paint",
+                "fileId": "file-1",
+                "type": "function",
+                "shortName": "Paint",
+                "qualifiedName": "Paint",
+                "startLine": 10,
+                "endLine": 14,
+                "signature": "void Paint()",
+            },
+        ]
+        self.symbol_by_id = {
+            str(symbol["symbolId"]): symbol
+            for symbol in self.symbols
+        }
+        self.data = []
+        self.modules = {}
+
+
+class FunctionGraphSourceServiceTests(unittest.TestCase):
+    def test_extract_function_source_returns_raw_text_and_fingerprint(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            project_root = Path(temp_dir)
+            (project_root / "sample.cpp").write_text(
+                "\n".join(
+                    [
+                        "#include <cstdint>",
+                        "",
+                        "int add(int lhs, int rhs)",
+                        "{",
+                        "    return lhs + rhs;",
+                        "}",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            service = FunctionGraphSourceService(project_root=project_root, index=FakeIndex())
+            result = service.extract_function_source("fn-1")
+
+        expected_text = "\n".join(
+            [
+                "int add(int lhs, int rhs)",
+                "{",
+                "    return lhs + rhs;",
+                "}",
+            ]
+        ) + "\n"
+        self.assertEqual(result.text, expected_text)
+        self.assertEqual(result.symbol_id, "fn-1")
+        self.assertEqual(result.relative_path, "sample.cpp")
+        self.assertEqual(result.start_line, 3)
+        self.assertEqual(result.end_line, 6)
+        self.assertEqual(result.base_line, 3)
+        self.assertEqual(result.base_byte, len("#include <cstdint>\n\n".encode("utf-8")))
+        self.assertEqual(result.function_body_fingerprint, text_fingerprint(expected_text))
+
+    def test_missing_symbol_returns_structured_error(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            service = FunctionGraphSourceService(project_root=Path(temp_dir), index=FakeIndex())
+
+            with self.assertRaises(FunctionGraphSourceError) as raised:
+                service.extract_function_source("missing")
+
+        self.assertEqual(raised.exception.error.code, "symbol_not_found")
+        self.assertEqual(raised.exception.error.symbol_id, "missing")
+
+    def test_non_callable_symbol_returns_structured_error(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            service = FunctionGraphSourceService(project_root=Path(temp_dir), index=FakeIndex())
+
+            with self.assertRaises(FunctionGraphSourceError) as raised:
+                service.extract_function_source("class-1")
+
+        self.assertEqual(raised.exception.error.code, "not_callable_symbol")
+        self.assertEqual(raised.exception.error.symbol_id, "class-1")
+
+    def test_empty_graph_result_has_stable_contract(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            project_root = Path(temp_dir)
+            (project_root / "sample.cpp").write_text(
+                "\n".join(
+                    [
+                        "#include <cstdint>",
+                        "",
+                        "int add(int lhs, int rhs)",
+                        "{",
+                        "    return lhs + rhs;",
+                        "}",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            service = FunctionGraphSourceService(project_root=project_root, index=FakeIndex())
+            first = service.build_empty_graph_result(FunctionGraphRequest(symbol_id="fn-1"))
+            second = service.build_empty_graph_result("fn-1")
+
+        self.assertEqual(first.schema, FUNCTION_GRAPH_SCHEMA)
+        self.assertEqual(first.status, "computed")
+        self.assertFalse(first.from_cache)
+        self.assertEqual(first.symbol_id, "fn-1")
+        self.assertEqual(first.function_name, "add")
+        self.assertEqual(first.file, "sample.cpp")
+        self.assertEqual(first.start_line, 3)
+        self.assertEqual(first.end_line, 6)
+        self.assertIsNone(first.parser_id)
+        self.assertIsNone(first.parser_version)
+        self.assertIsNone(first.resolver_version)
+        self.assertEqual(first.claim_strength, SOURCE_STRUCTURE_CLAIM_STRENGTH)
+        self.assertEqual(first.behavior_claims_allowed, BEHAVIOR_CLAIMS_ALLOWED)
+        self.assertEqual(first.edges, ())
+        self.assertTrue(first.fingerprints.function_body.startswith("sha256:"))
+        self.assertTrue(first.fingerprints.graph.startswith("sha256:"))
+        self.assertEqual(first.fingerprints.graph, second.fingerprints.graph)
+
+    def test_get_function_body_graph_computes_and_returns_cached_graph(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            project_root = Path(temp_dir)
+            index_root = project_root / ".mcp-cpp-project-indexer"
+            (project_root / "sample.cpp").write_text(
+                "\n".join(
+                    [
+                        "#include <windows.h>",
+                        "",
+                        "int add(int lhs, int rhs)",
+                        "{",
+                        "    return lhs + rhs;",
+                        "}",
+                        "",
+                        "void Helper();",
+                        "",
+                        "void Paint()",
+                        "{",
+                        "    Helper();",
+                        "    SendMessageW();",
+                        "}",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            service = FunctionGraphSourceService(
+                project_root=project_root,
+                index=FakeIndex(),
+                index_root=index_root,
+            )
+            request = FunctionGraphRequest(symbol_id="fn-paint", mode="compute_if_missing")
+
+            first = service.get_function_body_graph(
+                request,
+                file_fingerprint="sha256:file",
+                symbol_index_fingerprint="sha256:symbols",
+                module_visibility_fingerprint="sha256:modules",
+            )
+            second = service.get_function_body_graph(
+                FunctionGraphRequest(symbol_id="fn-paint", mode="cache_only"),
+                file_fingerprint="sha256:file",
+                symbol_index_fingerprint="sha256:symbols",
+                module_visibility_fingerprint="sha256:modules",
+            )
+            xrefs_from = service.get_call_xrefs_from("fn-paint")
+            xrefs_to = service.get_call_xrefs_to("fn-helper")
+            neighborhood = service.get_symbol_neighborhood("fn-helper")
+
+        self.assertEqual(first.status, "computed")
+        self.assertFalse(first.from_cache)
+        self.assertEqual(first.claim_strength, SOURCE_STRUCTURE_CLAIM_STRENGTH)
+        self.assertFalse(first.behavior_claims_allowed)
+        self.assertEqual(
+            {(edge.to_text, edge.resolution_status) for edge in first.edges},
+            {("Helper", "probable"), ("SendMessageW", "external")},
+        )
+        self.assertEqual(second.status, "computed")
+        self.assertTrue(second.from_cache)
+        self.assertEqual(second.fingerprints.graph, first.fingerprints.graph)
+        self.assertEqual(xrefs_from["direction"], "from")
+        self.assertEqual(xrefs_from["returnedEdges"], 2)
+        self.assertFalse(xrefs_from["behaviorClaimsAllowed"])
+        self.assertEqual(xrefs_to["direction"], "to")
+        self.assertEqual(xrefs_to["returnedEdges"], 1)
+        self.assertEqual(xrefs_to["edges"][0]["fromSymbolId"], "fn-paint")
+        self.assertEqual(neighborhood["target"]["symbolId"], "fn-helper")
+        self.assertEqual(neighborhood["callerCount"], 1)
+        self.assertEqual(neighborhood["callers"][0]["symbolId"], "fn-paint")
+        self.assertFalse(neighborhood["behaviorClaimsAllowed"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cpp_function_graph_storage.py
+++ b/tests/test_cpp_function_graph_storage.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import sys
+import unittest
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INDEXER_SRC = REPO_ROOT / "src" / "indexer"
+if str(INDEXER_SRC) not in sys.path:
+    sys.path.insert(0, str(INDEXER_SRC))
+
+from cpp_function_graph_cache import (
+    FunctionGraphCacheKey,
+    ast_cache_key_for_extract,
+    graph_cache_key_for_result,
+)
+from cpp_function_graph_model import (
+    FUNCTION_GRAPH_SCHEMA,
+    SOURCE_STRUCTURE_CLAIM_STRENGTH,
+    FunctionAstExtract,
+    FunctionGraphEdge,
+    FunctionGraphFingerprints,
+    FunctionGraphResult,
+)
+from cpp_function_graph_storage import FunctionGraphStorage, function_graph_db_path
+from cpp_index_sqlite import SQLITE_INDEX_FILENAME
+
+
+class FunctionGraphStorageTests(unittest.TestCase):
+    def test_ast_extract_cache_round_trip_uses_existing_index_db_path(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            index_root = Path(temp_dir) / ".mcp-cpp-project-indexer"
+            storage = FunctionGraphStorage.from_index_root(index_root)
+            extract = FunctionAstExtract(
+                symbol_id="fn-paint",
+                source_fingerprint="sha256:source",
+                parser_id="fixture",
+                parser_version="v1",
+                extractor_version="extractor-v1",
+                calls=(
+                    {
+                        "callee": "Draw",
+                        "line": 12,
+                    },
+                ),
+            )
+
+            key = ast_cache_key_for_extract(extract)
+            storage.store_ast_extract(key, extract)
+            loaded = storage.load_ast_extract(key)
+
+            self.assertEqual(function_graph_db_path(index_root).name, SQLITE_INDEX_FILENAME)
+            self.assertIsNotNone(loaded)
+            self.assertEqual(loaded, extract)
+
+    def test_graph_cache_round_trip_and_edge_lookup(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            storage = FunctionGraphStorage.from_index_root(Path(temp_dir) / ".mcp-cpp-project-indexer")
+            edge = FunctionGraphEdge(
+                from_symbol_id="fn-paint",
+                edge_kind="calls_candidate",
+                to_text="Draw",
+                to_symbol_id="fn-draw",
+                resolution_status="probable",
+                confidence=0.82,
+                basis=("same_namespace", "same_file"),
+                candidates=(
+                    {
+                        "symbolId": "fn-draw",
+                        "qualifiedName": "App::Draw",
+                    },
+                ),
+            )
+            result = FunctionGraphResult(
+                schema=FUNCTION_GRAPH_SCHEMA,
+                status="computed",
+                from_cache=False,
+                symbol_id="fn-paint",
+                function_name="Paint",
+                qualified_name="App::Painter::Paint",
+                file="paint.cpp",
+                start_line=10,
+                end_line=15,
+                parser_id="fixture",
+                parser_version="v1",
+                resolver_version="resolver-v1",
+                claim_strength=SOURCE_STRUCTURE_CLAIM_STRENGTH,
+                behavior_claims_allowed=False,
+                fingerprints=FunctionGraphFingerprints(
+                    function_body="sha256:source",
+                    graph="sha256:graph",
+                    file="sha256:file",
+                    symbol_index="sha256:symbols",
+                    module_visibility="sha256:modules",
+                ),
+                edges=(edge,),
+            )
+            key = graph_cache_key_for_result(
+                result,
+                file_fingerprint="sha256:file",
+                symbol_index_fingerprint="sha256:symbols",
+                module_visibility_fingerprint="sha256:modules",
+            )
+
+            storage.store_graph_result(key, result)
+            loaded = storage.load_graph_result(key)
+            from_edges = storage.list_edges_from("fn-paint")
+            to_edges = storage.list_edges_to("fn-draw")
+
+        self.assertIsNotNone(loaded)
+        self.assertEqual(loaded.fingerprints.graph, "sha256:graph")
+        self.assertEqual(loaded.edges, (edge,))
+        self.assertEqual(len(from_edges), 1)
+        self.assertEqual(from_edges[0]["toSymbolId"], "fn-draw")
+        self.assertEqual(from_edges[0]["claimStrength"], SOURCE_STRUCTURE_CLAIM_STRENGTH)
+        self.assertFalse(from_edges[0]["behaviorClaimsAllowed"])
+        self.assertEqual(to_edges, from_edges)
+
+    def test_graph_cache_miss_when_visibility_fingerprint_changes(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            storage = FunctionGraphStorage.from_index_root(Path(temp_dir) / ".mcp-cpp-project-indexer")
+            result = FunctionGraphResult(
+                schema=FUNCTION_GRAPH_SCHEMA,
+                status="computed",
+                from_cache=False,
+                symbol_id="fn-paint",
+                function_name="Paint",
+                qualified_name="App::Painter::Paint",
+                file="paint.cpp",
+                start_line=10,
+                end_line=15,
+                parser_id="fixture",
+                parser_version="v1",
+                resolver_version="resolver-v1",
+                claim_strength=SOURCE_STRUCTURE_CLAIM_STRENGTH,
+                behavior_claims_allowed=False,
+                fingerprints=FunctionGraphFingerprints(
+                    function_body="sha256:source",
+                    graph="sha256:graph",
+                ),
+                edges=(),
+            )
+            key = FunctionGraphCacheKey(
+                function_symbol_id="fn-paint",
+                function_body_fingerprint="sha256:source",
+                file_fingerprint="sha256:file",
+                symbol_index_fingerprint="sha256:symbols",
+                module_visibility_fingerprint="sha256:modules-a",
+                parser_id="fixture",
+                parser_version="v1",
+                resolver_version="resolver-v1",
+            )
+            changed_visibility_key = FunctionGraphCacheKey(
+                function_symbol_id="fn-paint",
+                function_body_fingerprint="sha256:source",
+                file_fingerprint="sha256:file",
+                symbol_index_fingerprint="sha256:symbols",
+                module_visibility_fingerprint="sha256:modules-b",
+                parser_id="fixture",
+                parser_version="v1",
+                resolver_version="resolver-v1",
+            )
+
+            storage.store_graph_result(key, result)
+
+            self.assertIsNotNone(storage.load_graph_result(key))
+            self.assertIsNone(storage.load_graph_result(changed_visibility_key))
+
+    def test_storing_new_graph_replaces_outgoing_edges_for_symbol(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            storage = FunctionGraphStorage.from_index_root(Path(temp_dir) / ".mcp-cpp-project-indexer")
+
+            def make_result(graph_fingerprint: str, callee: str) -> FunctionGraphResult:
+                return FunctionGraphResult(
+                    schema=FUNCTION_GRAPH_SCHEMA,
+                    status="computed",
+                    from_cache=False,
+                    symbol_id="fn-paint",
+                    function_name="Paint",
+                    qualified_name="App::Painter::Paint",
+                    file="paint.cpp",
+                    start_line=10,
+                    end_line=15,
+                    parser_id="fixture",
+                    parser_version="v1",
+                    resolver_version="resolver-v1",
+                    claim_strength=SOURCE_STRUCTURE_CLAIM_STRENGTH,
+                    behavior_claims_allowed=False,
+                    fingerprints=FunctionGraphFingerprints(
+                        function_body="sha256:source",
+                        graph=graph_fingerprint,
+                        file="sha256:file",
+                        symbol_index="sha256:symbols",
+                        module_visibility="sha256:modules",
+                    ),
+                    edges=(
+                        FunctionGraphEdge(
+                            from_symbol_id="fn-paint",
+                            edge_kind="calls_candidate",
+                            to_text=callee,
+                            to_symbol_id=f"fn-{callee.casefold()}",
+                            resolution_status="probable",
+                            confidence=0.82,
+                            basis=("same_file",),
+                        ),
+                    ),
+                )
+
+            first = make_result("sha256:graph-a", "OldHelper")
+            second = make_result("sha256:graph-b", "NewHelper")
+            storage.store_graph_result(
+                graph_cache_key_for_result(
+                    first,
+                    file_fingerprint="sha256:file",
+                    symbol_index_fingerprint="sha256:symbols",
+                    module_visibility_fingerprint="sha256:modules",
+                ),
+                first,
+            )
+            storage.store_graph_result(
+                graph_cache_key_for_result(
+                    second,
+                    file_fingerprint="sha256:file",
+                    symbol_index_fingerprint="sha256:symbols",
+                    module_visibility_fingerprint="sha256:modules",
+                ),
+                second,
+            )
+
+            edges = storage.list_edges_from("fn-paint")
+
+        self.assertEqual(len(edges), 1)
+        self.assertEqual(edges[0]["toText"], "NewHelper")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cpp_function_graph_visibility.py
+++ b/tests/test_cpp_function_graph_visibility.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import sys
+import unittest
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INDEXER_SRC = REPO_ROOT / "src" / "indexer"
+if str(INDEXER_SRC) not in sys.path:
+    sys.path.insert(0, str(INDEXER_SRC))
+
+from cpp_function_graph_model import FunctionAstExtract, FunctionSourceSlice
+from cpp_function_graph_visibility import build_function_visibility_context
+
+
+class FakeVisibilityIndex:
+    uses_sqlite = False
+
+    def __init__(self) -> None:
+        self.modules = {
+            "App.Core": ["file-1", "file-2"],
+        }
+        self.symbol_by_id = {
+            "cls-1": {
+                "symbolId": "cls-1",
+                "fileId": "file-1",
+                "relativePath": "paint.cpp",
+                "type": "class",
+                "shortName": "Painter",
+                "qualifiedName": "App::Painter",
+                "container": "App",
+                "startLine": 3,
+                "endLine": 20,
+                "signature": "class Painter",
+            },
+            "fn-paint": {
+                "symbolId": "fn-paint",
+                "fileId": "file-1",
+                "relativePath": "paint.cpp",
+                "type": "method",
+                "shortName": "Paint",
+                "qualifiedName": "App::Painter::Paint",
+                "container": "App::Painter",
+                "startLine": 10,
+                "endLine": 15,
+                "signature": "void Paint()",
+            },
+            "fn-helper": {
+                "symbolId": "fn-helper",
+                "fileId": "file-1",
+                "relativePath": "paint.cpp",
+                "type": "function",
+                "shortName": "Helper",
+                "qualifiedName": "App::Helper",
+                "container": "App",
+                "startLine": 22,
+                "endLine": 25,
+                "signature": "void Helper()",
+            },
+            "fn-exported": {
+                "symbolId": "fn-exported",
+                "fileId": "file-2",
+                "relativePath": "module.cppm",
+                "type": "function",
+                "shortName": "Draw",
+                "qualifiedName": "App::Draw",
+                "container": "App",
+                "startLine": 5,
+                "endLine": 7,
+                "signature": "void Draw()",
+            },
+        }
+        self.symbols = list(self.symbol_by_id.values())
+        self.data = [
+            {
+                "dataId": "data-overlay",
+                "fileId": "file-1",
+                "relativePath": "paint.cpp",
+                "declarationKind": "field",
+                "name": "_OverlayPosition",
+                "shortName": "_OverlayPosition",
+                "qualifiedName": "App::Painter::_OverlayPosition",
+                "container": "App::Painter",
+                "typeText": "int",
+                "startLine": 6,
+                "endLine": 6,
+            },
+            {
+                "dataId": "data-global",
+                "fileId": "file-1",
+                "relativePath": "paint.cpp",
+                "declarationKind": "variable",
+                "name": "g_count",
+                "shortName": "g_count",
+                "qualifiedName": "App::g_count",
+                "container": "App",
+                "typeText": "int",
+                "startLine": 2,
+                "endLine": 2,
+            },
+        ]
+        self.using_declarations = [
+            {
+                "fileId": "file-1",
+                "name": "Draw",
+                "target": "App::Theme::Draw",
+                "activeFromLine": 1,
+                "activeToLine": 200,
+            },
+        ]
+        self.using_directives = [
+            {
+                "fileId": "file-1",
+                "namespace": "App::Theme",
+                "activeFromLine": 1,
+                "activeToLine": 200,
+            },
+        ]
+        self.namespace_aliases = [
+            {
+                "fileId": "file-1",
+                "alias": "Theme",
+                "target": "App::Theme",
+                "activeFromLine": 1,
+                "activeToLine": 200,
+            },
+        ]
+
+
+class FunctionGraphVisibilityTests(unittest.TestCase):
+    def test_visibility_context_includes_same_file_class_module_and_member_data(self) -> None:
+        index = FakeVisibilityIndex()
+        source = FunctionSourceSlice(
+            symbol_id="fn-paint",
+            function_name="Paint",
+            qualified_name="App::Painter::Paint",
+            symbol_type="method",
+            file_id="file-1",
+            relative_path="paint.cpp",
+            start_line=10,
+            end_line=15,
+            base_line=10,
+            base_byte=100,
+            text="void Painter::Paint() {}",
+            function_body_fingerprint="sha256:source",
+        )
+        ast_extract = FunctionAstExtract(
+            symbol_id="fn-paint",
+            source_fingerprint="sha256:source",
+            parser_id="fixture",
+            parser_version="v1",
+            extractor_version="v1",
+            local_declarations=(
+                {
+                    "name": "opacity",
+                    "typeText": "auto",
+                    "line": 12,
+                },
+            ),
+        )
+
+        context = build_function_visibility_context(index=index, source=source, ast_extract=ast_extract)
+
+        self.assertEqual(context.file_id, "file-1")
+        self.assertEqual(context.file_path, "paint.cpp")
+        self.assertEqual(context.function_symbol_id, "fn-paint")
+        self.assertEqual(context.current_namespace, ("App",))
+        self.assertEqual(context.current_class_symbol_id, "cls-1")
+        self.assertEqual(context.current_class_name, "App::Painter")
+        self.assertEqual(context.imported_modules, ("App.Core",))
+
+        same_file_ids = {item["symbolId"] for item in context.same_file_symbols}
+        self.assertIn("fn-helper", same_file_ids)
+        self.assertIn("cls-1", same_file_ids)
+
+        visible_ids = {item["symbolId"] for item in context.visible_exported_symbols}
+        self.assertIn("fn-exported", visible_ids)
+
+        member_data_ids = {item["dataId"] for item in context.member_data}
+        self.assertEqual(member_data_ids, {"data-overlay"})
+
+        local_names = {item["name"] for item in context.local_declarations}
+        self.assertEqual(local_names, {"opacity"})
+        self.assertEqual(context.using_declarations[0]["target"], "App::Theme::Draw")
+        self.assertEqual(context.using_directives[0]["namespace"], "App::Theme")
+        self.assertEqual(context.namespace_aliases[0]["alias"], "Theme")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add on-demand function-body graph contracts, parser adapter, extraction, visibility, resolver, SQLite cache/storage, and service layer
- expose compact structural MCP tools: `get_function_body_graph`, `get_call_xrefs_from`, `get_call_xrefs_to`, `get_symbol_neighborhood`
- add data/control-flow structural edges and a persisted real-index MCP smoke test
- document completed workplans and phase worklogs

## Safety / Scope
- graph output is structural only: `claimStrength=source_structure_allowed`, `behaviorClaimsAllowed=false`
- no Tree-sitter dependency added; lightweight parser remains behind adapter
- no external API semantic resolution, no vector sidecar, no second provider/tool loop

## Tests
- `python -m unittest discover -s tests -p "test_*.py"` (27 tests)
- `python -m py_compile ...` on touched function graph/server/test files
- `git diff --check`
- persisted real-index smoke via `CodeIndexTools.get_function_body_graph` / cache / xrefs / data-control flags