### PR TITLE
Harden function graph accuracy and cache maintenance

### DIFF
--- a/docs/function-graph-tools.md
+++ b/docs/function-graph-tools.md
@@ -1,0 +1,33 @@
+# Function Graph MCP Tools
+
+The function graph tools expose project-local source structure from indexed C++ function bodies. They are for navigation and structural review, not behavior proof.
+
+## `get_function_body_graph`
+
+Use this first when you need the calls, data accesses, and control-flow markers inside one indexed callable symbol.
+
+Important arguments:
+
+- `symbolId`: indexed callable symbol id.
+- `mode`: `compute_if_missing`, `cache_only`, or `refresh`.
+- `includeDataAccess`: include read/write data candidate edges.
+- `includeControlFlow`: include syntax markers such as `if`, `return`, and loops.
+- `includeExternal`: include unresolved non-project calls as `external`.
+
+The response includes parser/resolver versions, cache status, fingerprints, edges, `claimStrength=source_structure_allowed`, and `behaviorClaimsAllowed=false`.
+
+## Xrefs And Neighborhood
+
+`get_call_xrefs_from`, `get_call_xrefs_to`, and `get_symbol_neighborhood` read persisted graph edges only. They do not compute missing graphs. Compute or refresh `get_function_body_graph` for relevant callers before relying on xref completeness.
+
+## Cache Modes
+
+- `compute_if_missing`: reuse a compatible cached graph or compute it.
+- `cache_only`: return only compatible cached graphs; otherwise return `cache_miss`.
+- `refresh`: recompute and replace persisted edges for that symbol.
+
+Graph cache compatibility includes source fingerprints, parser/resolver versions, visibility fingerprints, and graph options such as data/control/external edge flags and `maxEdges`.
+
+## Claim Contract
+
+Function graph output may say a source structure was observed or a project-local candidate was found. It must not claim runtime behavior, side effects, alias certainty, dynamic dispatch certainty, or external API semantics.

--- a/docs/work/P13-function-graph-workplan-hygiene.md
+++ b/docs/work/P13-function-graph-workplan-hygiene.md
@@ -1,0 +1,21 @@
+# P13 Function Graph Workplan Hygiene
+
+Implemented phase: Function Graph Hardening Slice P13.
+
+## Changed
+
+- Added completed workplan `docs/workplans/completed/function-graph-hardening.md`.
+- Updated `docs/workplans/README.md` completed map.
+- Renamed `docs/work/README.md` from active-only wording to completed function graph logs.
+
+## Runtime Ownership
+
+Documentation only. No runtime owner changed.
+
+## Verification
+
+Final verification for this slice is covered by `git diff --check`.
+
+## Non-Goals Respected
+
+No runtime behavior, MCP schema, parser, resolver, or storage behavior changed in this slice.

--- a/docs/work/P14-tree-sitter-adapter-gate.md
+++ b/docs/work/P14-tree-sitter-adapter-gate.md
@@ -1,0 +1,22 @@
+# P14 Tree-sitter Adapter Gate
+
+Implemented phase: Function Graph Hardening Slice P14.
+
+## Changed
+
+- `src/indexer/cpp_function_graph_tree_sitter.py` now exposes a dependency status helper.
+- The Tree-sitter adapter remains optional and unavailable by default.
+- If optional packages are absent, callers get a structured unavailable reason.
+- If optional packages are present, the adapter still refuses activation until extraction parity is implemented.
+
+## Runtime Ownership
+
+`src/indexer` owns parser adapter selection. `FunctionGraphSourceService` continues to use `LightweightFunctionBodyParser` by default.
+
+## Verification
+
+- `tests/test_cpp_function_graph_extract.py` asserts adapter isolation and dependency status reporting.
+
+## Non-Goals Respected
+
+No hard Tree-sitter dependency was added. No second parser loop was introduced.

--- a/docs/work/P15-indexed-using-visibility.md
+++ b/docs/work/P15-indexed-using-visibility.md
@@ -1,0 +1,23 @@
+# P15 Indexed Using Visibility
+
+Implemented phase: Function Graph Hardening Slice P15.
+
+## Changed
+
+- `src/indexer/cpp_structural_scan.py` extracts file-scope and namespace-scope `using` declarations, `using namespace` directives, and namespace aliases.
+- `src/indexer/cpp_file_index.py` stores those lists in each file index.
+- `src/indexer/cpp_function_graph_visibility.py` loads those visibility candidates from in-memory index attributes or the persisted file index.
+- The resolver continues to treat these as project-local candidates, not compiler-semantic proof.
+
+## Runtime Ownership
+
+The indexer owns extraction and persistence. Function graph visibility owns compact context construction.
+
+## Verification
+
+- `tests/test_cpp_function_graph_visibility.py` covers file-index-backed scope item loading.
+- `tests/test_cpp_function_graph_mcp_smoke.py` covers real index build plus MCP graph resolution through `using namespace`.
+
+## Non-Goals Respected
+
+No new MCP tools. No behavior claims. No compiler-level overload or alias certainty.

--- a/docs/work/P16-cache-fingerprint-hardening.md
+++ b/docs/work/P16-cache-fingerprint-hardening.md
@@ -1,0 +1,22 @@
+# P16 Cache Fingerprint Hardening
+
+Implemented phase: Function Graph Hardening Slice P16.
+
+## Changed
+
+- `src/indexer/cpp_function_graph_cache.py` adds structured graph cache options and stable option fingerprints.
+- `src/indexer/cpp_function_graph_service.py` uses the option fingerprint in the resolver cache version.
+- Graph fingerprints record the normalized graph options and their fingerprint.
+
+## Runtime Ownership
+
+Function graph cache ownership stays in `src/indexer`.
+SQLite storage schema stays unchanged.
+
+## Verification
+
+- `tests/test_cpp_function_graph_source.py` asserts cache miss when graph options differ.
+
+## Non-Goals Respected
+
+No API shape change. No second storage root. No broad cache migration.

--- a/docs/work/P17-function-graph-operator-docs.md
+++ b/docs/work/P17-function-graph-operator-docs.md
@@ -1,0 +1,20 @@
+# P17 Function Graph Operator Docs
+
+Implemented phase: Function Graph Hardening Slice P17.
+
+## Changed
+
+- Added `docs/function-graph-tools.md` with compact usage guidance for existing function graph MCP tools.
+- Documented cache modes, xref/neighborhood behavior, and the no-behavior-claims contract.
+
+## Runtime Ownership
+
+Documentation only. Server tool ownership remains in `src/server/code_index_mcp_server.py`.
+
+## Verification
+
+Final verification for this slice is covered by `git diff --check`.
+
+## Non-Goals Respected
+
+No new public MCP endpoint. No tool-list expansion.

--- a/docs/work/P18-hardening-patch-finalization.md
+++ b/docs/work/P18-hardening-patch-finalization.md
@@ -1,0 +1,21 @@
+# P18 Hardening Patch Finalization
+
+Implemented phase: Function Graph Accuracy and Maintenance Slice P18.
+
+## Changed
+
+- Continued the Function Graph work on branch `codex/function-graph-next-slices`.
+- Kept the patch scope to Function Graph source, tests, and docs.
+- Left unrelated dirty files unstaged and unmodified.
+
+## Runtime Ownership
+
+No runtime behavior change in this slice.
+
+## Verification
+
+Covered by final Python compile, unittest, and diff checks for the full slice set.
+
+## Non-Goals Respected
+
+No UI cleanup, no unrelated file cleanup, and no MCP tool expansion.

--- a/docs/work/P19-using-scope-precision.md
+++ b/docs/work/P19-using-scope-precision.md
@@ -1,0 +1,21 @@
+# P19 Using Scope Precision
+
+Implemented phase: Function Graph Accuracy and Maintenance Slice P19.
+
+## Changed
+
+- `src/indexer/cpp_structural_scan.py` now applies scope interval end lines to `using` declarations, `using namespace` directives, and namespace aliases.
+- Relative project namespaces are expanded from the current scope, for example `using namespace Theme;` inside `App` becomes `App::Theme`.
+- Known external roots such as `std` are not project-prefixed.
+
+## Runtime Ownership
+
+The structural scanner owns extraction. Function graph visibility consumes the persisted file-index candidates.
+
+## Verification
+
+- `tests/test_cpp_function_graph_visibility.py` verifies relative namespace expansion and active range end lines.
+
+## Non-Goals Respected
+
+No compiler lookup guarantee. Resolver output remains candidate-based.

--- a/docs/work/P20-tree-sitter-adapter-spike-decision.md
+++ b/docs/work/P20-tree-sitter-adapter-spike-decision.md
@@ -1,0 +1,21 @@
+# P20 Tree-sitter Adapter Spike Decision
+
+Implemented phase: Function Graph Accuracy and Maintenance Slice P20.
+
+## Changed
+
+- The optional Tree-sitter adapter remains gated behind dependency/status checks.
+- The lightweight parser remains the default parser for normal service execution.
+- Tree-sitter extraction parity is still required before enabling the adapter when optional dependencies are present.
+
+## Runtime Ownership
+
+Parser selection remains internal to `src/indexer`.
+
+## Verification
+
+- Existing adapter-unavailable tests continue to assert that optional Tree-sitter is not required.
+
+## Non-Goals Respected
+
+No hard dependency and no second parser loop.

--- a/docs/work/P21-resolver-candidate-quality.md
+++ b/docs/work/P21-resolver-candidate-quality.md
@@ -1,0 +1,21 @@
+# P21 Resolver Candidate Quality
+
+Implemented phase: Function Graph Accuracy and Maintenance Slice P21.
+
+## Changed
+
+- Member-call local type hints now match namespaced member containers by tail when the local type is unqualified.
+- Qualified data accesses add `qualified_data_name` basis when they match indexed project data.
+- Existing ambiguity behavior is preserved.
+
+## Runtime Ownership
+
+`src/indexer/cpp_function_graph_resolver.py` owns candidate scoring and structural edge resolution.
+
+## Verification
+
+- `tests/test_cpp_function_graph_resolver.py` covers local type tail matching and qualified data basis.
+
+## Non-Goals Respected
+
+No dynamic dispatch, alias certainty, side-effect, or behavior claims.

--- a/docs/work/P22-cache-storage-maintenance.md
+++ b/docs/work/P22-cache-storage-maintenance.md
@@ -1,0 +1,21 @@
+# P22 Cache Storage Maintenance
+
+Implemented phase: Function Graph Accuracy and Maintenance Slice P22.
+
+## Changed
+
+- `src/indexer/cpp_function_graph_storage.py` records lightweight function graph storage metadata.
+- Added cache stats for AST extracts, graph results, and graph edges.
+- Added parser/resolver version pruning for old cache rows and associated persisted edges.
+
+## Runtime Ownership
+
+Function graph cache/storage remains in the existing index SQLite database.
+
+## Verification
+
+- `tests/test_cpp_function_graph_storage.py` covers stats and version pruning.
+
+## Non-Goals Respected
+
+No new database, no sidecar, and no MCP API expansion.

--- a/docs/work/README.md
+++ b/docs/work/README.md
@@ -1,8 +1,8 @@
 # Work Logs
 
-This folder records implemented or prepared work slices for active workplans.
+This folder records implemented or prepared work slices for function graph workplans.
 
-## Active Logs
+## Completed Logs
 
 - [P00 Function Graph Preflight](P00-function-graph-preflight.md) - preflight for `docs/workplans/on-demand-cpp-function-body-relation-graph.md`.
 - [P01 Function Source Extraction](P01-function-source-extraction.md) - Step 1 runtime slice for indexed function source extraction.
@@ -17,7 +17,13 @@ This folder records implemented or prepared work slices for active workplans.
 - [P10 Optional Vector Sidecar Deferred](P10-optional-vector-sidecar-deferred.md) - Step 10 explicit future-work deferral, no runtime implementation.
 - [P11 Data and Control-Flow Edges](P11-data-control-flow-edges.md) - graph edge expansion for data access and control-flow markers.
 - [P12 Real Index MCP Smoke](P12-real-index-mcp-smoke.md) - persisted real-index CodeIndexTools smoke for graph/cache/xref edges.
-
-## Completed Logs
-
-- Function graph workplan logs P00-P10 are complete for the initial implementation.
+- [P13 Function Graph Workplan Hygiene](P13-function-graph-workplan-hygiene.md) - follow-up workplan closure and worklog README cleanup.
+- [P14 Tree-sitter Adapter Gate](P14-tree-sitter-adapter-gate.md) - optional dependency status gate while preserving lightweight parser fallback.
+- [P15 Indexed Using Visibility](P15-indexed-using-visibility.md) - file-index using declarations/directives and namespace alias visibility input.
+- [P16 Cache Fingerprint Hardening](P16-cache-fingerprint-hardening.md) - structured graph option cache fingerprints.
+- [P17 Function Graph Operator Docs](P17-function-graph-operator-docs.md) - compact MCP tool usage documentation.
+- [P18 Hardening Patch Finalization](P18-hardening-patch-finalization.md) - dedicated branch and review-ready Function Graph scope.
+- [P19 Using Scope Precision](P19-using-scope-precision.md) - scope-bounded using/alias candidates and relative namespace expansion.
+- [P20 Tree-sitter Adapter Spike Decision](P20-tree-sitter-adapter-spike-decision.md) - optional adapter remains gated without hard dependency.
+- [P21 Resolver Candidate Quality](P21-resolver-candidate-quality.md) - improved member and data candidate quality without behavior claims.
+- [P22 Cache Storage Maintenance](P22-cache-storage-maintenance.md) - graph cache stats and version pruning.

--- a/docs/workplans/README.md
+++ b/docs/workplans/README.md
@@ -8,3 +8,5 @@ None.
 
 - [On-Demand C++ Function Body Relation Graph](completed/on-demand-cpp-function-body-relation-graph.md) - completed initial implementation, 2026-06-17.
 - [Function Graph Edge Expansion](completed/function-graph-edge-expansion.md) - completed data/control-flow edge follow-up, 2026-06-17.
+- [Function Graph Hardening](completed/function-graph-hardening.md) - completed follow-up slices for worklog hygiene, parser gating, indexed using visibility, cache keys, and operator docs, 2026-06-17.
+- [Function Graph Accuracy and Maintenance](completed/function-graph-accuracy-maintenance.md) - completed next slices for hardening finalization, using-scope precision, adapter spike decision, resolver candidates, and cache maintenance, 2026-06-18.

--- a/docs/workplans/completed/function-graph-accuracy-maintenance.md
+++ b/docs/workplans/completed/function-graph-accuracy-maintenance.md
@@ -1,0 +1,28 @@
+# Workplan: Function Graph Accuracy and Maintenance
+
+Date: 2026-06-18
+Status: completed
+
+## Summary
+
+This follow-up keeps the existing Function Graph MCP surface stable while improving candidate precision and cache maintenance. It does not add tools, behavior claims, or required parser dependencies.
+
+## Completed Slices
+
+1. P18 hardening patch finalization on a dedicated branch.
+2. P19 using-scope precision with scope-bounded active ranges and relative namespace expansion.
+3. P20 Tree-sitter real adapter spike decision: keep optional adapter gated until dependency and extraction parity are available.
+4. P21 resolver candidate quality for local type hints and qualified data candidates.
+5. P22 cache/storage maintenance with stats and parser/resolver version pruning.
+
+## Ownership
+
+`src/indexer` owns scanning, parser adapters, visibility, resolver, cache, and storage.
+`src/server` owns MCP schema and dispatch only; no server tool expansion was needed.
+
+## Non-Goals
+
+No new public MCP tools.
+No hard Tree-sitter dependency.
+No vector sidecar.
+No behavior evidence; output remains `source_structure_allowed` and `behaviorClaimsAllowed=false`.

--- a/docs/workplans/completed/function-graph-hardening.md
+++ b/docs/workplans/completed/function-graph-hardening.md
@@ -1,0 +1,29 @@
+# Workplan: Function Graph Hardening
+
+Date: 2026-06-17
+Status: completed
+
+## Summary
+
+Follow-up slices after the on-demand function graph merge. The work hardens the existing function graph path without adding MCP tools: worklog hygiene, optional Tree-sitter dependency gating, indexed `using` visibility, explicit graph cache option fingerprints, and compact operator documentation.
+
+## Completed Slices
+
+1. P13 Workplan and worklog hygiene.
+2. P14 Tree-sitter dependency decision and adapter gate.
+3. P15 Indexed `using` declarations, `using namespace` directives, and namespace aliases as visibility candidates.
+4. P16 Structured graph option fingerprints for cache separation.
+5. P17 Operator-facing MCP function graph documentation.
+
+## Ownership
+
+Production function graph logic remains under `src/indexer`.
+MCP exposure remains under `src/server/code_index_mcp_server.py`.
+Documentation lives under `docs/workplans`, `docs/work`, and `docs/function-graph-tools.md`.
+
+## Non-Goals
+
+No new public MCP tools.
+No hard Tree-sitter dependency.
+No second parser loop, provider loop, or tool loop.
+No behavior claims; function graph output remains `source_structure_allowed` with `behaviorClaimsAllowed=false`.

--- a/src/indexer/cpp_file_index.py
+++ b/src/indexer/cpp_file_index.py
@@ -372,6 +372,9 @@ def build_file_index(
         "exports": exports,
         "symbols": symbols,
         "data": data_items,
+        "usingDeclarations": structural_scan.using_declarations,
+        "usingDirectives": structural_scan.using_directives,
+        "namespaceAliases": structural_scan.namespace_aliases,
         "diagnostics": diagnostics_to_json(diagnostics),
     }
 
@@ -425,5 +428,8 @@ def summarize_file_index(file_index: dict[str, Any]) -> dict[str, Any]:
         "scopeIntervals": len(file_index.get("scopeIntervals", [])),
         "structuralEvents": len(file_index.get("structuralEvents", [])),
         "functionBodyRanges": len(file_index.get("functionBodyRanges", [])),
+        "usingDeclarations": len(file_index.get("usingDeclarations", [])),
+        "usingDirectives": len(file_index.get("usingDirectives", [])),
+        "namespaceAliases": len(file_index.get("namespaceAliases", [])),
         "diagnostics": len(file_index.get("diagnostics", [])),
     }

--- a/src/indexer/cpp_function_graph_cache.py
+++ b/src/indexer/cpp_function_graph_cache.py
@@ -6,7 +6,7 @@ import json
 from dataclasses import dataclass
 from typing import Any
 
-from cpp_function_graph_model import FunctionAstExtract, FunctionGraphResult
+from cpp_function_graph_model import FunctionAstExtract, FunctionGraphRequest, FunctionGraphResult
 
 
 @dataclass(frozen=True, slots=True)
@@ -30,9 +30,39 @@ class FunctionGraphCacheKey:
     resolver_version: str
 
 
+@dataclass(frozen=True, slots=True)
+class FunctionGraphCacheOptions:
+    include_control_flow: bool
+    include_data_access: bool
+    include_external: bool
+    max_edges: int
+
+
 def stable_json_fingerprint(payload: Any) -> str:
     text = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
     return "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def graph_cache_options_for_request(request: FunctionGraphRequest) -> FunctionGraphCacheOptions:
+    return FunctionGraphCacheOptions(
+        include_control_flow=bool(request.include_control_flow),
+        include_data_access=bool(request.include_data_access),
+        include_external=bool(request.include_external),
+        max_edges=max(1, int(request.max_edges)),
+    )
+
+
+def graph_cache_options_payload(options: FunctionGraphCacheOptions) -> dict[str, Any]:
+    return {
+        "includeControlFlow": options.include_control_flow,
+        "includeDataAccess": options.include_data_access,
+        "includeExternal": options.include_external,
+        "maxEdges": options.max_edges,
+    }
+
+
+def graph_cache_options_fingerprint(options: FunctionGraphCacheOptions) -> str:
+    return stable_json_fingerprint(graph_cache_options_payload(options))
 
 
 def ast_cache_key_for_extract(extract: FunctionAstExtract) -> FunctionAstCacheKey:

--- a/src/indexer/cpp_function_graph_resolver.py
+++ b/src/indexer/cpp_function_graph_resolver.py
@@ -284,10 +284,14 @@ def _data_candidates(text: str, visibility: FunctionVisibilityContext) -> tuple[
         if _data_name(item) != tail:
             continue
         candidate = dict(item)
+        basis: list[str] = []
+        if "::" in text and _qualified_data_matches(text, item):
+            basis.append("qualified_data_name")
         if item in visibility.member_data:
-            candidate["_basis"] = ("indexed_member_data",)
+            basis.append("indexed_member_data")
         else:
-            candidate["_basis"] = ("indexed_same_file_data",)
+            basis.append("indexed_same_file_data")
+        candidate["_basis"] = tuple(basis)
         result.append(candidate)
     return _dedupe_data_candidates(result)
 
@@ -420,7 +424,13 @@ def _same_container(symbol: dict[str, Any], container: str | None) -> bool:
     if not container:
         return False
     symbol_container = str(symbol.get("container") or "")
-    return symbol_container.casefold() == container.casefold()
+    symbol_container_folded = symbol_container.casefold()
+    container_folded = container.casefold()
+    return (
+        symbol_container_folded == container_folded
+        or symbol_container_folded.endswith("::" + container_folded)
+        or container_folded.endswith("::" + symbol_container_folded)
+    )
 
 
 def _same_namespace(symbol: dict[str, Any], visibility: FunctionVisibilityContext) -> bool:
@@ -454,7 +464,11 @@ def _matches_using_directive(symbol: dict[str, Any], visibility: FunctionVisibil
     container_folded = container.casefold()
     for item in visibility.using_directives:
         namespace = str(item.get("namespace") or item.get("target") or item.get("targetName") or "")
-        if namespace and container_folded == namespace.casefold():
+        namespace_folded = namespace.casefold()
+        if namespace and (
+            container_folded == namespace_folded
+            or container_folded.endswith("::" + namespace_folded)
+        ):
             return True
     return False
 
@@ -499,6 +513,9 @@ def _local_type_for_object(object_name: str, visibility: FunctionVisibilityConte
 
 def _normalize_type_name(type_text: str) -> str | None:
     text = type_text.replace("const ", "").replace("*", "").replace("&", "").strip()
+    for prefix in ("class ", "struct "):
+        if text.startswith(prefix):
+            text = text[len(prefix):].strip()
     return text or None
 
 
@@ -532,6 +549,15 @@ def _member_tail(text: str) -> str:
 
 def _data_name(item: dict[str, Any]) -> str:
     return str(item.get("shortName") or item.get("name") or "").rsplit("::", 1)[-1]
+
+
+def _qualified_data_matches(text: str, item: dict[str, Any]) -> bool:
+    qualified_name = str(item.get("qualifiedName") or "")
+    if qualified_name and qualified_name.casefold() == text.casefold():
+        return True
+    container = str(item.get("container") or "")
+    name = _data_name(item)
+    return bool(container and name and f"{container}::{name}".casefold() == text.casefold())
 
 
 def _merge_data_basis(candidates: tuple[dict[str, Any], ...], fallback: tuple[str, ...]) -> tuple[str, ...]:

--- a/src/indexer/cpp_function_graph_service.py
+++ b/src/indexer/cpp_function_graph_service.py
@@ -11,6 +11,9 @@ from cpp_function_graph_cache import (
     FunctionAstCacheKey,
     FunctionGraphCacheKey,
     ast_cache_key_for_extract,
+    graph_cache_options_fingerprint,
+    graph_cache_options_for_request,
+    graph_cache_options_payload,
     stable_json_fingerprint,
 )
 from cpp_function_graph_extract import EXTRACTOR_VERSION, LightweightFunctionBodyParser
@@ -194,6 +197,8 @@ class FunctionGraphSourceService:
             else request_or_symbol_id
         )
         source = self.extract_function_source(request.symbol_id)
+        cache_options = graph_cache_options_for_request(request)
+        cache_options_fingerprint = graph_cache_options_fingerprint(cache_options)
         cache_resolver_version = _cache_resolver_version(request)
         graph_key = FunctionGraphCacheKey(
             function_symbol_id=source.symbol_id,
@@ -229,6 +234,7 @@ class FunctionGraphSourceService:
                             "parser": self.parser.parser_id,
                             "resolver": RESOLVER_VERSION,
                             "cacheResolver": cache_resolver_version,
+                            "graphOptionsFingerprint": cache_options_fingerprint,
                         }
                     ),
                     file=file_fingerprint,
@@ -284,6 +290,8 @@ class FunctionGraphSourceService:
                 },
                 "resolverVersion": RESOLVER_VERSION,
                 "cacheResolverVersion": cache_resolver_version,
+                "graphOptions": graph_cache_options_payload(cache_options),
+                "graphOptionsFingerprint": cache_options_fingerprint,
                 "edges": [asdict(edge) for edge in edges],
             }
         )
@@ -496,10 +504,5 @@ def _unique_edge_symbol_ids(edges: tuple[dict[str, Any], ...], *, key: str) -> t
 
 
 def _cache_resolver_version(request: FunctionGraphRequest) -> str:
-    return (
-        f"{RESOLVER_VERSION};"
-        f"cf={int(request.include_control_flow)};"
-        f"da={int(request.include_data_access)};"
-        f"ex={int(request.include_external)};"
-        f"max={request.max_edges}"
-    )
+    options = graph_cache_options_for_request(request)
+    return f"{RESOLVER_VERSION};options={graph_cache_options_fingerprint(options)}"

--- a/src/indexer/cpp_function_graph_storage.py
+++ b/src/indexer/cpp_function_graph_storage.py
@@ -73,6 +73,12 @@ def initialize_function_graph_storage(connection: sqlite3.Connection) -> None:
             evidence_json TEXT NOT NULL
         );
 
+        CREATE TABLE IF NOT EXISTS function_graph_metadata (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL,
+            updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+
         CREATE INDEX IF NOT EXISTS idx_function_graph_cache_lookup
             ON function_graph_cache(
                 function_symbol_id,
@@ -161,6 +167,15 @@ class FunctionGraphStorage:
     def store_graph_result(self, key: FunctionGraphCacheKey, result: FunctionGraphResult) -> None:
         graph_fingerprint = result.fingerprints.graph
         with self.connect() as connection:
+            self._store_metadata(
+                connection,
+                {
+                    "schema": FUNCTION_GRAPH_STORAGE_SCHEMA,
+                    "lastParserId": key.parser_id,
+                    "lastParserVersion": key.parser_version,
+                    "lastResolverVersion": key.resolver_version,
+                },
+            )
             connection.execute(
                 """
                 INSERT OR REPLACE INTO function_graph_cache(
@@ -288,6 +303,88 @@ class FunctionGraphStorage:
 
         return tuple(_edge_row_to_dict(row) for row in rows)
 
+    def cache_stats(self) -> dict[str, int]:
+        with self.connect() as connection:
+            return {
+                "astExtracts": _count_rows(connection, "function_ast_extract_cache"),
+                "graphResults": _count_rows(connection, "function_graph_cache"),
+                "graphEdges": _count_rows(connection, "function_graph_edges"),
+            }
+
+    def prune_cache_versions(
+        self,
+        *,
+        keep_parser_versions: set[str] | None = None,
+        keep_resolver_versions: set[str] | None = None,
+    ) -> dict[str, int]:
+        keep_parser_versions = set(keep_parser_versions or ())
+        keep_resolver_versions = set(keep_resolver_versions or ())
+
+        with self.connect() as connection:
+            before = self._cache_counts(connection)
+            stale_graphs = connection.execute(
+                """
+                SELECT graph_fingerprint
+                FROM function_graph_cache
+                WHERE (? = 1 OR parser_version NOT IN (%s))
+                   OR (? = 1 OR resolver_version NOT IN (%s))
+                """
+                % (
+                    _placeholders(keep_parser_versions),
+                    _placeholders(keep_resolver_versions),
+                ),
+                (
+                    1 if not keep_parser_versions else 0,
+                    *sorted(keep_parser_versions),
+                    1 if not keep_resolver_versions else 0,
+                    *sorted(keep_resolver_versions),
+                ),
+            ).fetchall()
+            stale_fingerprints = [str(row["graph_fingerprint"]) for row in stale_graphs]
+
+            if stale_fingerprints:
+                connection.execute(
+                    "DELETE FROM function_graph_edges WHERE graph_fingerprint IN (%s)"
+                    % _placeholders(stale_fingerprints),
+                    stale_fingerprints,
+                )
+                connection.execute(
+                    "DELETE FROM function_graph_cache WHERE graph_fingerprint IN (%s)"
+                    % _placeholders(stale_fingerprints),
+                    stale_fingerprints,
+                )
+
+            if keep_parser_versions:
+                connection.execute(
+                    "DELETE FROM function_ast_extract_cache WHERE parser_version NOT IN (%s)"
+                    % _placeholders(keep_parser_versions),
+                    sorted(keep_parser_versions),
+                )
+
+            after = self._cache_counts(connection)
+
+        return {
+            "astExtractsPruned": before["astExtracts"] - after["astExtracts"],
+            "graphResultsPruned": before["graphResults"] - after["graphResults"],
+            "graphEdgesPruned": before["graphEdges"] - after["graphEdges"],
+        }
+
+    def _cache_counts(self, connection: sqlite3.Connection) -> dict[str, int]:
+        return {
+            "astExtracts": _count_rows(connection, "function_ast_extract_cache"),
+            "graphResults": _count_rows(connection, "function_graph_cache"),
+            "graphEdges": _count_rows(connection, "function_graph_edges"),
+        }
+
+    def _store_metadata(self, connection: sqlite3.Connection, values: dict[str, Any]) -> None:
+        connection.executemany(
+            """
+            INSERT OR REPLACE INTO function_graph_metadata(key, value, updated_at)
+            VALUES(?, ?, CURRENT_TIMESTAMP)
+            """,
+            [(key, _json_dump(value)) for key, value in values.items()],
+        )
+
 
 def _ast_extract_from_payload(payload: dict[str, Any]) -> FunctionAstExtract:
     return FunctionAstExtract(
@@ -365,3 +462,15 @@ def _edge_row_to_dict(row: sqlite3.Row) -> dict[str, Any]:
 
 def _json_dump(payload: Any) -> str:
     return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def _count_rows(connection: sqlite3.Connection, table: str) -> int:
+    if table not in {"function_ast_extract_cache", "function_graph_cache", "function_graph_edges"}:
+        raise ValueError("Invalid function graph storage table.")
+    return int(connection.execute(f"SELECT COUNT(*) AS count FROM {table}").fetchone()["count"])
+
+
+def _placeholders(values: set[str] | list[str]) -> str:
+    if not values:
+        return "NULL"
+    return ",".join("?" for _ in values)

--- a/src/indexer/cpp_function_graph_tree_sitter.py
+++ b/src/indexer/cpp_function_graph_tree_sitter.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import importlib.util
+
 from cpp_function_graph_model import FunctionAstExtract
 
 
@@ -7,14 +9,44 @@ class TreeSitterUnavailableError(RuntimeError):
     pass
 
 
+def tree_sitter_cpp_dependency_status() -> dict[str, str | bool]:
+    """Return dependency status without importing optional packages eagerly."""
+
+    missing = [
+        package
+        for package in ("tree_sitter", "tree_sitter_cpp")
+        if importlib.util.find_spec(package) is None
+    ]
+    if missing:
+        return {
+            "available": False,
+            "reason": "missing_optional_dependency",
+            "packages": ",".join(missing),
+        }
+
+    return {
+        "available": True,
+        "reason": "dependency_present_adapter_not_enabled",
+        "packages": "tree_sitter,tree_sitter_cpp",
+    }
+
+
 class TreeSitterCppFunctionBodyParser:
     parser_id = "tree-sitter-cpp"
-    parser_version = "unavailable"
+    parser_version = "optional-gated"
 
     def __init__(self) -> None:
+        status = tree_sitter_cpp_dependency_status()
+        if status["available"]:
+            raise TreeSitterUnavailableError(
+                "Tree-sitter C++ dependencies are present, but the function graph "
+                "Tree-sitter extraction adapter is not enabled yet. Use the "
+                "lightweight parser fallback until the adapter has extraction parity."
+            )
+
         raise TreeSitterUnavailableError(
-            "Tree-sitter C++ is not configured for this project yet. "
-            "Use LightweightFunctionBodyParser for tests until the dependency is added."
+            "Tree-sitter C++ optional dependencies are not configured for this project: "
+            f"{status['packages']}. Use LightweightFunctionBodyParser fallback."
         )
 
     def parse_function(

--- a/src/indexer/cpp_function_graph_visibility.py
+++ b/src/indexer/cpp_function_graph_visibility.py
@@ -24,9 +24,9 @@ def build_function_visibility_context(
     imported_modules = _module_names_for_file(index, source.file_id)
     visible_exported_symbols = _visible_module_symbols(index, imported_modules, source.file_id)
     member_data = _member_data(file_data, current_class_name)
-    using_declarations = _scope_items_for_file(index, "using_declarations", source.file_id, source.start_line)
-    using_directives = _scope_items_for_file(index, "using_directives", source.file_id, source.start_line)
-    namespace_aliases = _scope_items_for_file(index, "namespace_aliases", source.file_id, source.start_line)
+    using_declarations = _scope_items_for_file(index, "using_declarations", "usingDeclarations", source.file_id, source.start_line)
+    using_directives = _scope_items_for_file(index, "using_directives", "usingDirectives", source.file_id, source.start_line)
+    namespace_aliases = _scope_items_for_file(index, "namespace_aliases", "namespaceAliases", source.file_id, source.start_line)
 
     return FunctionVisibilityContext(
         file_id=source.file_id,
@@ -167,11 +167,25 @@ def _member_data(file_data: list[dict[str, Any]], current_class_name: str | None
     return result
 
 
-def _scope_items_for_file(index: Any, attr_name: str, file_id: str, line: int) -> list[dict[str, Any]]:
+def _scope_items_for_file(index: Any, attr_name: str, file_index_key: str, file_id: str, line: int) -> list[dict[str, Any]]:
     result: list[dict[str, Any]] = []
-    for item in getattr(index, attr_name, []) or []:
-        if str(item.get("fileId") or "") != file_id:
+    loaded_from_file_index = False
+    source_items = list(getattr(index, attr_name, []) or [])
+
+    if not source_items and hasattr(index, "load_file_index"):
+        try:
+            file_index = index.load_file_index(file_id)
+        except (OSError, ValueError, KeyError, TypeError):
+            file_index = {}
+        source_items = list(file_index.get(file_index_key, []) or [])
+        loaded_from_file_index = True
+
+    for item in source_items:
+        item_file_id = str(item.get("fileId") or "")
+        if item_file_id and item_file_id != file_id:
             continue
+        if loaded_from_file_index and not item_file_id:
+            item = {**item, "fileId": file_id}
         active_from = int(item.get("activeFromLine") or item.get("startLine") or 1)
         active_to = int(item.get("activeToLine") or item.get("endLine") or 2**31 - 1)
         if active_from <= line <= active_to:

--- a/src/indexer/cpp_index_model.py
+++ b/src/indexer/cpp_index_model.py
@@ -7,7 +7,7 @@ from typing import Any
 SCHEMA_NAME = "cpp.file_index.v1"
 INDEXER_NAME = "vs-project-indexer"
 INDEXER_VERSION = "0.1"
-SCANNER_VERSION = "cpp-structural-scan.v1"
+SCANNER_VERSION = "cpp-structural-scan.v2"
 
 
 MODULE_UNIT_KINDS = {

--- a/src/indexer/cpp_structural_scan.py
+++ b/src/indexer/cpp_structural_scan.py
@@ -33,6 +33,9 @@ class StructuralScanResult:
     scope_map: list[list[ScopeFrame]]
     scope_intervals: list[dict[str, Any]]
     function_body_ranges: list[dict[str, Any]]
+    using_declarations: list[dict[str, Any]]
+    using_directives: list[dict[str, Any]]
+    namespace_aliases: list[dict[str, Any]]
     diagnostics: list[Diagnostic]
     token_count: int
 
@@ -840,6 +843,147 @@ def is_inside_non_declaration_body(brace_stack: list[BraceRecord]) -> bool:
     )
 
 
+def _scope_qualified_name(scope_stack: list[ScopeFrame]) -> str:
+    for frame in reversed(scope_stack):
+        if frame.kind in {"namespace", "class", "struct"} and (frame.qualified_name or frame.name):
+            return frame.qualified_name or frame.name
+    return ""
+
+
+def _active_to_line(scope_stack: list[ScopeFrame], total_lines: int) -> int:
+    return total_lines
+
+
+EXTERNAL_NAMESPACE_ROOTS = {"std", "boost", "ATL", "wil", "Microsoft", "Windows"}
+
+
+def _normalize_qualified_text(tokens: list[Token]) -> str:
+    text = tokens_to_text(tokens)
+    return (
+        text
+        .replace(" :: ", "::")
+        .replace(":: ", "::")
+        .replace(" ::", "::")
+        .strip()
+    )
+
+
+def _scope_relative_name(name: str, scope_stack: list[ScopeFrame]) -> str:
+    if not name:
+        return ""
+    if name.startswith("::"):
+        return name.lstrip(":")
+    if not scope_stack:
+        return name
+
+    root = name.split("::", 1)[0]
+    if root in EXTERNAL_NAMESPACE_ROOTS:
+        return name
+
+    scope = _scope_qualified_name(scope_stack)
+    if not scope:
+        return name
+    if name == scope or name.startswith(scope + "::"):
+        return name
+    return f"{scope}::{name}"
+
+
+def classify_using_statement(
+    segment: list[Token],
+    *,
+    scope_stack: list[ScopeFrame],
+    total_lines: int,
+) -> tuple[str, dict[str, Any]] | None:
+    values = token_values(segment)
+
+    if not values:
+        return None
+
+    if values[0] == "namespace" and len(values) >= 4 and values[2] == "=":
+        alias = values[1]
+        target = _scope_relative_name(_normalize_qualified_text(segment[3:]), scope_stack)
+        if alias and target:
+            return "namespace_alias", {
+                "alias": alias,
+                "target": target,
+                "qualifiedName": build_qualified_name(scope_stack, alias),
+                "scope": _scope_qualified_name(scope_stack),
+                "startLine": segment[0].line,
+                "endLine": segment[-1].line,
+                "activeFromLine": segment[-1].line + 1,
+                "activeToLine": _active_to_line(scope_stack, total_lines),
+            }
+
+    if values[0] != "using":
+        return None
+
+    if len(values) >= 3 and values[1] == "namespace":
+        namespace = _scope_relative_name(_normalize_qualified_text(segment[2:]), scope_stack)
+        if namespace:
+            return "using_directive", {
+                "namespace": namespace,
+                "scope": _scope_qualified_name(scope_stack),
+                "startLine": segment[0].line,
+                "endLine": segment[-1].line,
+                "activeFromLine": segment[-1].line + 1,
+                "activeToLine": _active_to_line(scope_stack, total_lines),
+            }
+
+    target = _scope_relative_name(_normalize_qualified_text(segment[1:]), scope_stack)
+    if target and "=" not in values:
+        return "using_declaration", {
+            "name": target.rsplit("::", 1)[-1],
+            "target": target,
+            "scope": _scope_qualified_name(scope_stack),
+            "startLine": segment[0].line,
+            "endLine": segment[-1].line,
+            "activeFromLine": segment[-1].line + 1,
+            "activeToLine": _active_to_line(scope_stack, total_lines),
+        }
+
+    return None
+
+
+def apply_using_scope_ranges(
+    items: list[dict[str, Any]],
+    *,
+    scope_intervals: list[dict[str, Any]],
+    total_lines: int,
+) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for item in items:
+        scoped = dict(item)
+        scope = str(scoped.get("scope") or "")
+        if not scope:
+            scoped["activeToLine"] = total_lines
+            result.append(scoped)
+            continue
+
+        start_line = int(scoped.get("startLine") or scoped.get("activeFromLine") or 1)
+        candidates: list[dict[str, Any]] = []
+        for interval in scope_intervals:
+            if str(interval.get("qualifiedName") or "") != scope:
+                continue
+            range_item = interval.get("range") or {}
+            interval_start = int(range_item.get("startLine") or 0)
+            interval_end = int(range_item.get("endLine") or 0)
+            if interval_start <= start_line <= interval_end:
+                candidates.append(interval)
+
+        if candidates:
+            candidates.sort(
+                key=lambda interval: (
+                    int((interval.get("range") or {}).get("endLine") or total_lines)
+                    - int((interval.get("range") or {}).get("startLine") or 1)
+                )
+            )
+            scoped["activeToLine"] = int((candidates[0].get("range") or {}).get("endLine") or total_lines)
+        else:
+            scoped["activeToLine"] = total_lines
+        result.append(scoped)
+    return result
+
+
 # ---------------------------------------------------------------------------
 # Main structure scan
 # ---------------------------------------------------------------------------
@@ -852,6 +996,9 @@ def scan_structure(
     tokens = tokenize_lines(lines)
     events: list[StructuralEvent] = []
     diagnostics: list[Diagnostic] = []
+    using_declarations: list[dict[str, Any]] = []
+    using_directives: list[dict[str, Any]] = []
+    namespace_aliases: list[dict[str, Any]] = []
 
     scope_stack: list[ScopeFrame] = []
     brace_stack: list[BraceRecord] = []
@@ -1141,6 +1288,22 @@ def scan_structure(
             raw_segment = tokens[statement_start:index]
             template_prefixes, segment = parse_template_prefixes(raw_segment, lines)
 
+            using_statement = classify_using_statement(
+                segment,
+                scope_stack=scope_stack,
+                total_lines=len(lines),
+            )
+            if using_statement is not None:
+                kind, item = using_statement
+                if kind == "using_declaration":
+                    using_declarations.append(item)
+                elif kind == "using_directive":
+                    using_directives.append(item)
+                elif kind == "namespace_alias":
+                    namespace_aliases.append(item)
+                statement_start = index + 1
+                continue
+
             if should_skip_declaration_statement(segment):
                 statement_start = index + 1
                 continue
@@ -1266,12 +1429,30 @@ def scan_structure(
     scope_map = build_scope_map_from_events(events=events, total_lines=len(lines))
     scope_intervals = build_scope_intervals(events)
     function_body_ranges = build_function_body_ranges(events)
+    using_declarations = apply_using_scope_ranges(
+        using_declarations,
+        scope_intervals=scope_intervals,
+        total_lines=len(lines),
+    )
+    using_directives = apply_using_scope_ranges(
+        using_directives,
+        scope_intervals=scope_intervals,
+        total_lines=len(lines),
+    )
+    namespace_aliases = apply_using_scope_ranges(
+        namespace_aliases,
+        scope_intervals=scope_intervals,
+        total_lines=len(lines),
+    )
 
     return StructuralScanResult(
         events=events,
         scope_map=scope_map,
         scope_intervals=scope_intervals,
         function_body_ranges=function_body_ranges,
+        using_declarations=using_declarations,
+        using_directives=using_directives,
+        namespace_aliases=namespace_aliases,
         diagnostics=diagnostics,
         token_count=len(tokens),
     )

--- a/tests/test_cpp_function_graph_extract.py
+++ b/tests/test_cpp_function_graph_extract.py
@@ -12,7 +12,11 @@ if str(INDEXER_SRC) not in sys.path:
     sys.path.insert(0, str(INDEXER_SRC))
 
 from cpp_function_graph_extract import LightweightFunctionBodyParser, extract_raw_function_ast
-from cpp_function_graph_tree_sitter import TreeSitterCppFunctionBodyParser, TreeSitterUnavailableError
+from cpp_function_graph_tree_sitter import (
+    TreeSitterCppFunctionBodyParser,
+    TreeSitterUnavailableError,
+    tree_sitter_cpp_dependency_status,
+)
 
 
 class FunctionGraphRawExtractionTests(unittest.TestCase):
@@ -79,6 +83,10 @@ class FunctionGraphRawExtractionTests(unittest.TestCase):
         self.assertEqual(extract.calls[0]["line"], 12)
 
     def test_tree_sitter_adapter_is_isolated_until_dependency_exists(self) -> None:
+        status = tree_sitter_cpp_dependency_status()
+        self.assertIn(status["available"], {True, False})
+        self.assertIn("reason", status)
+
         with self.assertRaises(TreeSitterUnavailableError):
             TreeSitterCppFunctionBodyParser()
 

--- a/tests/test_cpp_function_graph_mcp_smoke.py
+++ b/tests/test_cpp_function_graph_mcp_smoke.py
@@ -29,6 +29,8 @@ class FunctionGraphMcpSmokeTests(unittest.TestCase):
                 "\n".join(
                     [
                         "namespace App {",
+                        "namespace Theme { void Draw(); }",
+                        "using namespace App::Theme;",
                         "void Helper();",
                         "class Painter {",
                         "    int _OverlayPosition;",
@@ -36,11 +38,17 @@ class FunctionGraphMcpSmokeTests(unittest.TestCase):
                         "};",
                         "void Painter::Paint()",
                         "{",
+                        "    Draw();",
                         "    Helper();",
                         "    if (_OverlayPosition > 0) {",
                         "        _OverlayPosition = 1;",
                         "    }",
                         "    SendMessageW();",
+                        "}",
+                        "namespace Theme {",
+                        "void Draw()",
+                        "{",
+                        "}",
                         "}",
                         "void Helper()",
                         "{",
@@ -122,6 +130,7 @@ class FunctionGraphMcpSmokeTests(unittest.TestCase):
         self.assertFalse(graph["fromCache"])
         self.assertFalse(graph["behaviorClaimsAllowed"])
         self.assertIn(edge_statuses["Helper"], {"exact", "probable", "ambiguous"})
+        self.assertIn(edge_statuses["Draw"], {"exact", "probable", "ambiguous"})
         self.assertEqual(edge_statuses["SendMessageW"], "external")
         self.assertIn("reads_data_candidate", edge_kinds)
         self.assertIn("writes_data_candidate", edge_kinds)

--- a/tests/test_cpp_function_graph_resolver.py
+++ b/tests/test_cpp_function_graph_resolver.py
@@ -390,6 +390,57 @@ class FunctionGraphResolverTests(unittest.TestCase):
         self.assertEqual(edges[0].to_symbol_id, "fn-renderer-draw")
         self.assertIn("local_type_hint", edges[0].basis)
 
+    def test_member_call_local_type_hint_matches_container_tail(self) -> None:
+        visibility = FunctionVisibilityContext(
+            file_id="file-1",
+            file_path="paint.cpp",
+            function_symbol_id="fn-paint",
+            current_namespace=("App",),
+            current_class_symbol_id=None,
+            current_class_name=None,
+            imported_modules=(),
+            visible_exported_symbols=(),
+            same_file_symbols=(
+                {
+                    "symbolId": "fn-widget-draw",
+                    "type": "method",
+                    "shortName": "Draw",
+                    "qualifiedName": "App::Widget::Draw",
+                    "container": "App::Widget",
+                    "signature": "void Draw()",
+                },
+            ),
+            same_file_data=(),
+            member_data=(),
+            local_declarations=(
+                {
+                    "name": "widget",
+                    "typeText": "Widget *",
+                },
+            ),
+        )
+        ast = FunctionAstExtract(
+            symbol_id="fn-paint",
+            source_fingerprint="sha256:source",
+            parser_id="fixture",
+            parser_version="v1",
+            extractor_version="v1",
+            calls=(
+                {
+                    "callee": "widget->Draw",
+                    "callKind": "member",
+                    "argumentCount": 0,
+                },
+            ),
+        )
+
+        edges = resolve_function_graph_edges(ast_extract=ast, visibility=visibility)
+
+        self.assertEqual(edges[0].edge_kind, "calls_candidate")
+        self.assertEqual(edges[0].resolution_status, "probable")
+        self.assertEqual(edges[0].to_symbol_id, "fn-widget-draw")
+        self.assertIn("local_type_hint", edges[0].basis)
+
     def test_data_access_and_control_flow_markers_are_structural_edges(self) -> None:
         visibility = FunctionVisibilityContext(
             file_id="file-1",
@@ -471,6 +522,49 @@ class FunctionGraphResolverTests(unittest.TestCase):
         )
 
         self.assertEqual(edges, ())
+
+    def test_qualified_data_access_records_qualified_basis(self) -> None:
+        visibility = FunctionVisibilityContext(
+            file_id="file-1",
+            file_path="paint.cpp",
+            function_symbol_id="fn-paint",
+            current_namespace=("App",),
+            current_class_symbol_id=None,
+            current_class_name=None,
+            imported_modules=(),
+            visible_exported_symbols=(),
+            same_file_symbols=(),
+            same_file_data=(
+                {
+                    "dataId": "data-count",
+                    "name": "g_count",
+                    "qualifiedName": "App::g_count",
+                    "container": "App",
+                    "typeText": "int",
+                },
+            ),
+            member_data=(),
+        )
+        ast = FunctionAstExtract(
+            symbol_id="fn-paint",
+            source_fingerprint="sha256:source",
+            parser_id="fixture",
+            parser_version="v1",
+            extractor_version="v1",
+            member_accesses=(
+                {
+                    "text": "App::g_count",
+                    "accessKind": "read_candidate",
+                },
+            ),
+        )
+
+        edges = resolve_function_graph_edges(ast_extract=ast, visibility=visibility)
+
+        self.assertEqual(edges[0].edge_kind, "reads_data_candidate")
+        self.assertEqual(edges[0].resolution_status, "probable")
+        self.assertEqual(edges[0].candidates[0]["dataId"], "data-count")
+        self.assertIn("qualified_data_name", edges[0].basis)
 
 
 if __name__ == "__main__":

--- a/tests/test_cpp_function_graph_source.py
+++ b/tests/test_cpp_function_graph_source.py
@@ -250,6 +250,61 @@ class FunctionGraphSourceServiceTests(unittest.TestCase):
         self.assertEqual(neighborhood["callers"][0]["symbolId"], "fn-paint")
         self.assertFalse(neighborhood["behaviorClaimsAllowed"])
 
+    def test_graph_cache_options_change_causes_cache_miss(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            project_root = Path(temp_dir)
+            index_root = project_root / ".mcp-cpp-project-indexer"
+            (project_root / "sample.cpp").write_text(
+                "\n".join(
+                    [
+                        "#include <windows.h>",
+                        "",
+                        "int add(int lhs, int rhs)",
+                        "{",
+                        "    return lhs + rhs;",
+                        "}",
+                        "",
+                        "void Helper();",
+                        "",
+                        "void Paint()",
+                        "{",
+                        "    Helper();",
+                        "    SendMessageW();",
+                        "}",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            service = FunctionGraphSourceService(
+                project_root=project_root,
+                index=FakeIndex(),
+                index_root=index_root,
+            )
+
+            first = service.get_function_body_graph(
+                FunctionGraphRequest(
+                    symbol_id="fn-paint",
+                    mode="compute_if_missing",
+                    include_external=False,
+                ),
+                file_fingerprint="sha256:file",
+                symbol_index_fingerprint="sha256:symbols",
+                module_visibility_fingerprint="sha256:modules",
+            )
+            second = service.get_function_body_graph(
+                FunctionGraphRequest(symbol_id="fn-paint", mode="cache_only"),
+                file_fingerprint="sha256:file",
+                symbol_index_fingerprint="sha256:symbols",
+                module_visibility_fingerprint="sha256:modules",
+            )
+
+        self.assertEqual(first.status, "computed")
+        self.assertFalse(first.from_cache)
+        self.assertEqual({edge.to_text for edge in first.edges}, {"Helper"})
+        self.assertEqual(second.status, "cache_miss")
+        self.assertFalse(second.from_cache)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cpp_function_graph_storage.py
+++ b/tests/test_cpp_function_graph_storage.py
@@ -235,6 +235,73 @@ class FunctionGraphStorageTests(unittest.TestCase):
         self.assertEqual(len(edges), 1)
         self.assertEqual(edges[0]["toText"], "NewHelper")
 
+    def test_cache_stats_and_prune_versions(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            storage = FunctionGraphStorage.from_index_root(Path(temp_dir) / ".mcp-cpp-project-indexer")
+
+            def make_result(graph_fingerprint: str, parser_version: str, resolver_version: str) -> FunctionGraphResult:
+                return FunctionGraphResult(
+                    schema=FUNCTION_GRAPH_SCHEMA,
+                    status="computed",
+                    from_cache=False,
+                    symbol_id=f"fn-{graph_fingerprint[-1]}",
+                    function_name="Paint",
+                    qualified_name="App::Painter::Paint",
+                    file="paint.cpp",
+                    start_line=10,
+                    end_line=15,
+                    parser_id="fixture",
+                    parser_version=parser_version,
+                    resolver_version=resolver_version,
+                    claim_strength=SOURCE_STRUCTURE_CLAIM_STRENGTH,
+                    behavior_claims_allowed=False,
+                    fingerprints=FunctionGraphFingerprints(
+                        function_body=f"sha256:source-{graph_fingerprint[-1]}",
+                        graph=graph_fingerprint,
+                        file="sha256:file",
+                        symbol_index="sha256:symbols",
+                        module_visibility="sha256:modules",
+                    ),
+                    edges=(
+                        FunctionGraphEdge(
+                            from_symbol_id=f"fn-{graph_fingerprint[-1]}",
+                            edge_kind="calls_candidate",
+                            to_text="Helper",
+                            to_symbol_id="fn-helper",
+                            resolution_status="probable",
+                            confidence=0.82,
+                            basis=("same_file",),
+                        ),
+                    ),
+                )
+
+            old_result = make_result("sha256:graph-a", "parser-old", "resolver-old")
+            current_result = make_result("sha256:graph-b", "parser-current", "resolver-current")
+            for result in (old_result, current_result):
+                storage.store_graph_result(
+                    graph_cache_key_for_result(
+                        result,
+                        file_fingerprint="sha256:file",
+                        symbol_index_fingerprint="sha256:symbols",
+                        module_visibility_fingerprint="sha256:modules",
+                    ),
+                    result,
+                )
+
+            before = storage.cache_stats()
+            pruned = storage.prune_cache_versions(
+                keep_parser_versions={"parser-current"},
+                keep_resolver_versions={"resolver-current"},
+            )
+            after = storage.cache_stats()
+
+        self.assertEqual(before["graphResults"], 2)
+        self.assertEqual(before["graphEdges"], 2)
+        self.assertEqual(pruned["graphResultsPruned"], 1)
+        self.assertEqual(pruned["graphEdgesPruned"], 1)
+        self.assertEqual(after["graphResults"], 1)
+        self.assertEqual(after["graphEdges"], 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cpp_function_graph_visibility.py
+++ b/tests/test_cpp_function_graph_visibility.py
@@ -4,6 +4,7 @@ import sys
 import unittest
 
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -13,6 +14,7 @@ if str(INDEXER_SRC) not in sys.path:
 
 from cpp_function_graph_model import FunctionAstExtract, FunctionSourceSlice
 from cpp_function_graph_visibility import build_function_visibility_context
+from cpp_file_index import build_file_index
 
 
 class FakeVisibilityIndex:
@@ -130,6 +132,38 @@ class FakeVisibilityIndex:
 
 
 class FunctionGraphVisibilityTests(unittest.TestCase):
+    def test_file_index_records_relative_using_namespace_with_scope_range(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            project_root = Path(temp_dir)
+            source_path = project_root / "sample.cpp"
+            source_path.write_text(
+                "\n".join(
+                    [
+                        "namespace App {",
+                        "namespace Theme { void Draw(); }",
+                        "using namespace Theme;",
+                        "void Paint()",
+                        "{",
+                        "}",
+                        "}",
+                        "void Outside()",
+                        "{",
+                        "}",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            file_index = build_file_index(path=source_path, project_root=project_root)
+
+        directives = file_index["usingDirectives"]
+        self.assertEqual(len(directives), 1)
+        self.assertEqual(directives[0]["namespace"], "App::Theme")
+        self.assertEqual(directives[0]["scope"], "App")
+        self.assertEqual(directives[0]["activeFromLine"], 4)
+        self.assertEqual(directives[0]["activeToLine"], 7)
+
     def test_visibility_context_includes_same_file_class_module_and_member_data(self) -> None:
         index = FakeVisibilityIndex()
         source = FunctionSourceSlice(
@@ -186,6 +220,69 @@ class FunctionGraphVisibilityTests(unittest.TestCase):
         self.assertEqual(context.using_declarations[0]["target"], "App::Theme::Draw")
         self.assertEqual(context.using_directives[0]["namespace"], "App::Theme")
         self.assertEqual(context.namespace_aliases[0]["alias"], "Theme")
+
+    def test_visibility_context_loads_using_scope_items_from_file_index(self) -> None:
+        index = FakeVisibilityIndex()
+        index.using_declarations = []
+        index.using_directives = []
+        index.namespace_aliases = []
+
+        def load_file_index(file_id: str) -> dict:
+            self.assertEqual(file_id, "file-1")
+            return {
+                "usingDeclarations": [
+                    {
+                        "name": "Draw",
+                        "target": "App::Theme::Draw",
+                        "startLine": 2,
+                        "endLine": 2,
+                        "activeFromLine": 3,
+                        "activeToLine": 50,
+                    },
+                ],
+                "usingDirectives": [
+                    {
+                        "namespace": "App::Theme",
+                        "startLine": 3,
+                        "endLine": 3,
+                        "activeFromLine": 4,
+                        "activeToLine": 50,
+                    },
+                ],
+                "namespaceAliases": [
+                    {
+                        "alias": "Theme",
+                        "target": "App::Theme",
+                        "startLine": 4,
+                        "endLine": 4,
+                        "activeFromLine": 5,
+                        "activeToLine": 50,
+                    },
+                ],
+            }
+
+        index.load_file_index = load_file_index
+        source = FunctionSourceSlice(
+            symbol_id="fn-paint",
+            function_name="Paint",
+            qualified_name="App::Painter::Paint",
+            symbol_type="method",
+            file_id="file-1",
+            relative_path="paint.cpp",
+            start_line=10,
+            end_line=15,
+            base_line=10,
+            base_byte=100,
+            text="void Painter::Paint() {}",
+            function_body_fingerprint="sha256:source",
+        )
+
+        context = build_function_visibility_context(index=index, source=source)
+
+        self.assertEqual(context.using_declarations[0]["fileId"], "file-1")
+        self.assertEqual(context.using_declarations[0]["target"], "App::Theme::Draw")
+        self.assertEqual(context.using_directives[0]["namespace"], "App::Theme")
+        self.assertEqual(context.namespace_aliases[0]["target"], "App::Theme")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- finalize Function Graph hardening docs/worklogs and keep the MCP tool surface unchanged
- add scope-bounded using/namespace alias visibility, relative namespace expansion, and resolver candidate quality improvements
- add structured graph option fingerprints plus cache stats/version pruning in existing SQLite storage

## Tests
- `python -m py_compile src/indexer/cpp_index_model.py src/indexer/cpp_structural_scan.py src/indexer/cpp_file_index.py src/indexer/cpp_function_graph_cache.py src/indexer/cpp_function_graph_service.py src/indexer/cpp_function_graph_tree_sitter.py src/indexer/cpp_function_graph_visibility.py src/indexer/cpp_function_graph_resolver.py src/indexer/cpp_function_graph_storage.py tests/test_cpp_function_graph_extract.py tests/test_cpp_function_graph_visibility.py tests/test_cpp_function_graph_source.py tests/test_cpp_function_graph_mcp_smoke.py tests/test_cpp_function_graph_resolver.py tests/test_cpp_function_graph_storage.py`
- `python -m unittest tests.test_cpp_function_graph_extract tests.test_cpp_function_graph_visibility tests.test_cpp_function_graph_source tests.test_cpp_function_graph_storage tests.test_cpp_function_graph_resolver tests.test_cpp_function_graph_mcp_schema tests.test_cpp_function_graph_mcp_smoke`
- `python -m unittest discover -s tests -p "test_*.py"`
- `git diff --check`
- `git diff --cached --check`

## Notes
- No new public MCP tools.
- Function graph output remains structural-only with `claimStrength=source_structure_allowed` and `behaviorClaimsAllowed=false`.
- Unrelated local dirty files were not included.