### PR TITLE
Expand function graph parser and ranking coverage

### DIFF
--- a/docs/function-graph-tools.md
+++ b/docs/function-graph-tools.md
@@ -28,6 +28,10 @@ The response includes parser/resolver versions, cache status, fingerprints, edge
 
 Graph cache compatibility includes source fingerprints, parser/resolver versions, visibility fingerprints, and graph options such as data/control/external edge flags and `maxEdges`.
 
+## Cache Maintenance
+
+Normal users should prefer rebuilding the project index when scanner inputs change and `refresh` when one function graph must be recomputed. Internal storage exposes cache stats and parser/resolver-version pruning for maintenance code, but no separate public MCP cache-maintenance tool is required.
+
 ## Claim Contract
 
 Function graph output may say a source structure was observed or a project-local candidate was found. It must not claim runtime behavior, side effects, alias certainty, dynamic dispatch certainty, or external API semantics.

--- a/docs/work/P23-pr6-ready-merge.md
+++ b/docs/work/P23-pr6-ready-merge.md
@@ -1,0 +1,18 @@
+# P23 PR 6 Ready and Merge
+
+Implemented phase: Function Graph Parser and Ranking Slice P23.
+
+## Changed
+
+- PR #6 was checked locally, marked ready for review, merged, and local `main` was fast-forwarded to `origin/main`.
+- New work continued from fresh branch `codex/function-graph-parser-ranking`.
+
+## Verification
+
+- `python -m py_compile ...`
+- `python -m unittest discover -s tests -p "test_*.py"`
+- `git diff --check`
+
+## Non-Goals Respected
+
+Unrelated dirty local files were not staged or changed.

--- a/docs/work/P24-parser-fixture-coverage.md
+++ b/docs/work/P24-parser-fixture-coverage.md
@@ -1,0 +1,17 @@
+# P24 Parser Fixture Coverage
+
+Implemented phase: Function Graph Parser and Ranking Slice P24.
+
+## Changed
+
+- Lightweight parser version moved to v0.2.
+- Template calls, chained result member calls, templated local declarations, and macro-like invocations have focused coverage.
+- Macro-like all-caps invocations are skipped as call edges.
+
+## Verification
+
+- `tests/test_cpp_function_graph_extract.py`
+
+## Non-Goals Respected
+
+Tree-sitter remains optional and gated.

--- a/docs/work/P25-real-project-smoke-expansion.md
+++ b/docs/work/P25-real-project-smoke-expansion.md
@@ -1,0 +1,16 @@
+# P25 Real Project Smoke Expansion
+
+Implemented phase: Function Graph Parser and Ranking Slice P25.
+
+## Changed
+
+- Real-index MCP smoke now builds a multi-file temporary C++ project.
+- The smoke computes more than one function graph and checks cache, xrefs, and symbol neighborhood output.
+
+## Verification
+
+- `tests/test_cpp_function_graph_mcp_smoke.py`
+
+## Non-Goals Respected
+
+No new MCP tool was added.

--- a/docs/work/P26-resolver-ranking-v03.md
+++ b/docs/work/P26-resolver-ranking-v03.md
@@ -1,0 +1,17 @@
+# P26 Resolver Ranking v0.3
+
+Implemented phase: Function Graph Parser and Ranking Slice P26.
+
+## Changed
+
+- Resolver version moved to `cpp-function-graph-resolver-v0.3`.
+- Ranking weights now more clearly prefer same-class and same-namespace candidates before lower-confidence fallback groups.
+- Tests cover same-namespace precedence over using/fallback/module candidates.
+
+## Verification
+
+- `tests/test_cpp_function_graph_resolver.py`
+
+## Non-Goals Respected
+
+Ambiguous candidates remain ambiguous; no fake exact behavior claims were added.

--- a/docs/work/P27-cache-maintenance-ux.md
+++ b/docs/work/P27-cache-maintenance-ux.md
@@ -1,0 +1,16 @@
+# P27 Cache Maintenance UX
+
+Implemented phase: Function Graph Parser and Ranking Slice P27.
+
+## Changed
+
+- `docs/function-graph-tools.md` now documents normal cache maintenance guidance.
+- Internal cache stats and version pruning remain internal storage capabilities, not public MCP tools.
+
+## Verification
+
+- `git diff --check`
+
+## Non-Goals Respected
+
+No public cache-maintenance tool was added.

--- a/docs/work/README.md
+++ b/docs/work/README.md
@@ -27,3 +27,8 @@ This folder records implemented or prepared work slices for function graph workp
 - [P20 Tree-sitter Adapter Spike Decision](P20-tree-sitter-adapter-spike-decision.md) - optional adapter remains gated without hard dependency.
 - [P21 Resolver Candidate Quality](P21-resolver-candidate-quality.md) - improved member and data candidate quality without behavior claims.
 - [P22 Cache Storage Maintenance](P22-cache-storage-maintenance.md) - graph cache stats and version pruning.
+- [P23 PR 6 Ready and Merge](P23-pr6-ready-merge.md) - PR #6 ready, merged, and local main synchronized.
+- [P24 Parser Fixture Coverage](P24-parser-fixture-coverage.md) - lightweight parser coverage for templates, lambdas, chained calls, and macro noise.
+- [P25 Real Project Smoke Expansion](P25-real-project-smoke-expansion.md) - multi-file real-index MCP smoke with multiple computed graphs.
+- [P26 Resolver Ranking v0.3](P26-resolver-ranking-v03.md) - resolver version bump and priority coverage.
+- [P27 Cache Maintenance UX](P27-cache-maintenance-ux.md) - internal cache maintenance documented without MCP tool expansion.

--- a/docs/workplans/README.md
+++ b/docs/workplans/README.md
@@ -10,3 +10,4 @@ None.
 - [Function Graph Edge Expansion](completed/function-graph-edge-expansion.md) - completed data/control-flow edge follow-up, 2026-06-17.
 - [Function Graph Hardening](completed/function-graph-hardening.md) - completed follow-up slices for worklog hygiene, parser gating, indexed using visibility, cache keys, and operator docs, 2026-06-17.
 - [Function Graph Accuracy and Maintenance](completed/function-graph-accuracy-maintenance.md) - completed next slices for hardening finalization, using-scope precision, adapter spike decision, resolver candidates, and cache maintenance, 2026-06-18.
+- [Function Graph Parser and Ranking](completed/function-graph-parser-ranking.md) - completed slices for PR #6 merge, parser fixtures, real-project smoke expansion, resolver ranking, and cache UX docs, 2026-06-18.

--- a/docs/workplans/completed/function-graph-parser-ranking.md
+++ b/docs/workplans/completed/function-graph-parser-ranking.md
@@ -1,0 +1,27 @@
+# Workplan: Function Graph Parser and Ranking
+
+Date: 2026-06-18
+Status: completed
+
+## Summary
+
+This slice set merged PR #6, then improved the existing Function Graph implementation on a fresh branch. It adds parser fixture coverage, broader real-index smoke coverage, resolver ranking v0.3, and cache maintenance documentation without adding public MCP tools.
+
+## Completed Slices
+
+1. P23 PR #6 ready, merge, and local `main` sync.
+2. P24 parser fixture coverage for templates, lambdas, chained calls, and macro noise.
+3. P25 multi-file real-project smoke expansion.
+4. P26 resolver ranking v0.3.
+5. P27 cache maintenance UX documentation.
+
+## Ownership
+
+Parser, resolver, cache, and storage remain under `src/indexer`.
+MCP exposure remains unchanged under `src/server`.
+
+## Non-Goals
+
+No new public MCP tools.
+No hard Tree-sitter dependency.
+No behavior claims or semantic execution claims.

--- a/src/indexer/cpp_function_graph_extract.py
+++ b/src/indexer/cpp_function_graph_extract.py
@@ -5,9 +5,9 @@ import re
 from cpp_function_graph_model import FunctionAstExtract
 
 
-EXTRACTOR_VERSION = "cpp-function-graph-raw-extractor-v0.1"
+EXTRACTOR_VERSION = "cpp-function-graph-raw-extractor-v0.2"
 LIGHTWEIGHT_PARSER_ID = "cpp-lightweight-function-parser"
-LIGHTWEIGHT_PARSER_VERSION = "v0.1"
+LIGHTWEIGHT_PARSER_VERSION = "v0.2"
 
 CONTROL_FLOW_WORDS = {
     "if",
@@ -33,15 +33,19 @@ CALL_EXCLUDE_WORDS = CONTROL_FLOW_WORDS | {
 }
 
 CALL_RE = re.compile(
-    r"(?P<callee>\b[A-Za-z_]\w*(?:(?:::|->|\.)[A-Za-z_]\w*)*)\s*\(",
+    r"(?P<callee>\b[A-Za-z_]\w*(?:(?:::|->|\.)[A-Za-z_]\w*)*)"
+    r"(?:\s*<[^;{}()]*>)?\s*\(",
+)
+CHAINED_RESULT_CALL_RE = re.compile(
+    r"(?:\)|\])\s*(?:->|\.)\s*(?P<callee>[A-Za-z_]\w*)\s*\(",
 )
 CONTROL_RE = re.compile(r"\b(if|switch|for|while|return|throw|try|catch|co_await|co_return)\b")
 LOCAL_DECL_RE = re.compile(
-    r"^\s*(?P<type>(?:const\s+)?(?:auto|[A-Za-z_]\w*(?:::[A-Za-z_]\w*)?)(?:\s*[*&])?)\s+"
+    r"^\s*(?P<type>(?:const\s+)?(?:auto|[A-Za-z_]\w*(?:::[A-Za-z_]\w*)?)(?:\s*<[^;=(){}]*>)?(?:\s*[*&])?)\s+"
     r"(?P<name>[A-Za-z_]\w*)\s*(?:[=;({])"
 )
-MEMBER_TOKEN_RE = re.compile(r"\b(?P<member>this->\w+|[A-Za-z_]\w*\.\w+|_\w+)\b")
-ASSIGNMENT_RE = re.compile(r"(?P<lhs>this->\w+|[A-Za-z_]\w*\.\w+|_\w+)\s*=")
+MEMBER_TOKEN_RE = re.compile(r"\b(?P<member>this->\w+(?:(?:->|\.)\w+)*|[A-Za-z_]\w*(?:(?:->|\.)\w+)+|_\w+)\b")
+ASSIGNMENT_RE = re.compile(r"(?P<lhs>this->\w+(?:(?:->|\.)\w+)*|[A-Za-z_]\w*(?:(?:->|\.)\w+)+|_\w+)\s*=")
 
 
 def extract_raw_function_ast(
@@ -91,17 +95,41 @@ def extract_raw_function_ast(
 
 def _extract_calls(line: str, *, line_number: int, byte_cursor: int) -> list[dict]:
     result: list[dict] = []
-    for match in CALL_RE.finditer(_strip_line_comment(line)):
+    stripped = _strip_line_comment(line)
+    seen: set[tuple[str, int]] = set()
+    for match in CALL_RE.finditer(stripped):
+        if match.start("callee") > 0 and stripped[match.start("callee") - 1] in {".", ">"}:
+            continue
         callee = match.group("callee")
         tail = callee.rsplit("::", 1)[-1].rsplit("->", 1)[-1].rsplit(".", 1)[-1]
-        if tail in CALL_EXCLUDE_WORDS:
+        if tail in CALL_EXCLUDE_WORDS or _looks_like_macro_invocation(tail):
             continue
 
+        seen.add((callee, match.start("callee")))
         result.append(
             {
                 "callee": callee,
                 "callKind": _call_kind(callee),
                 "argumentCount": _argument_count(line, match.end() - 1),
+                "line": line_number,
+                "column": match.start("callee"),
+                "byte": byte_cursor + len(line[:match.start("callee")].encode("utf-8")),
+                "kind": "call_expression",
+            }
+        )
+
+    for match in CHAINED_RESULT_CALL_RE.finditer(stripped):
+        callee = match.group("callee")
+        if callee in CALL_EXCLUDE_WORDS or _looks_like_macro_invocation(callee):
+            continue
+        key = (callee, match.start("callee"))
+        if key in seen:
+            continue
+        result.append(
+            {
+                "callee": callee,
+                "callKind": "member",
+                "argumentCount": _argument_count(stripped, match.end() - 1),
                 "line": line_number,
                 "column": match.start("callee"),
                 "byte": byte_cursor + len(line[:match.start("callee")].encode("utf-8")),
@@ -225,6 +253,10 @@ def _find_close_paren(line: str, open_paren_index: int) -> int | None:
 def _strip_line_comment(line: str) -> str:
     index = line.find("//")
     return line if index < 0 else line[:index]
+
+
+def _looks_like_macro_invocation(name: str) -> bool:
+    return name.isupper() or name.startswith(("ASSERT_", "VERIFY_", "TRACE_"))
 
 
 class LightweightFunctionBodyParser:

--- a/src/indexer/cpp_function_graph_resolver.py
+++ b/src/indexer/cpp_function_graph_resolver.py
@@ -11,7 +11,7 @@ from cpp_function_graph_model import (
 )
 
 
-RESOLVER_VERSION = "cpp-function-graph-resolver-v0.2"
+RESOLVER_VERSION = "cpp-function-graph-resolver-v0.3"
 EXTERNAL_QUALIFIER_PREFIXES = ("std::", "wil::", "ATL::", "Microsoft::WRL::")
 
 
@@ -330,14 +330,14 @@ def _score_candidates(candidates: Any, call: dict[str, Any]) -> tuple[dict[str, 
             "qualified_name": 0.35,
             "this_scope": 0.35,
             "current_class": 0.3,
-            "same_class": 0.25,
-            "same_namespace": 0.18,
+            "same_class": 0.28,
+            "same_namespace": 0.22,
             "using_declaration": 0.16,
             "using_namespace": 0.1,
             "local_type_hint": 0.22,
             "member_call": 0.08,
-            "same_file": 0.08,
-            "module_visible": 0.05,
+            "same_file": 0.05,
+            "module_visible": 0.03,
             "namespace_alias": 0.04,
         }
         for item in basis:

--- a/tests/test_cpp_function_graph_extract.py
+++ b/tests/test_cpp_function_graph_extract.py
@@ -82,6 +82,42 @@ class FunctionGraphRawExtractionTests(unittest.TestCase):
         self.assertEqual(extract.calls[0]["callee"], "foo")
         self.assertEqual(extract.calls[0]["line"], 12)
 
+    def test_extracts_templates_lambdas_chains_and_ignores_macro_noise(self) -> None:
+        function_text = "\n".join(
+            [
+                "void Paint()",
+                "{",
+                "    auto widget = MakeWidget<App::Widget>();",
+                "    auto fn = [&]() { widget.Draw(); return Helper(widget); };",
+                "    renderer.GetBrush().Reset();",
+                "    this->_State.Reset();",
+                "    ASSERT_TRUE(widget.IsReady());",
+                "}",
+            ]
+        )
+
+        extract = extract_raw_function_ast(
+            symbol_id="fn-paint",
+            source_fingerprint="sha256:source",
+            function_text=function_text,
+            base_line=20,
+            base_byte=0,
+        )
+
+        calls = {item["callee"]: item for item in extract.calls}
+        self.assertIn("MakeWidget", calls)
+        self.assertIn("widget.Draw", calls)
+        self.assertIn("Helper", calls)
+        self.assertIn("renderer.GetBrush", calls)
+        self.assertIn("Reset", calls)
+        self.assertIn("this->_State.Reset", calls)
+        self.assertNotIn("ASSERT_TRUE", calls)
+        self.assertEqual(calls["MakeWidget"]["argumentCount"], 0)
+        self.assertEqual(calls["Reset"]["callKind"], "member")
+
+        locals_by_name = {item["name"]: item for item in extract.local_declarations}
+        self.assertEqual(locals_by_name["widget"]["typeText"], "auto")
+
     def test_tree_sitter_adapter_is_isolated_until_dependency_exists(self) -> None:
         status = tree_sitter_cpp_dependency_status()
         self.assertIn(status["available"], {True, False})

--- a/tests/test_cpp_function_graph_mcp_smoke.py
+++ b/tests/test_cpp_function_graph_mcp_smoke.py
@@ -59,6 +59,27 @@ class FunctionGraphMcpSmokeTests(unittest.TestCase):
                 ),
                 encoding="utf-8",
             )
+            (project_root / "blend.cpp").write_text(
+                "\n".join(
+                    [
+                        "namespace App {",
+                        "void Helper();",
+                        "class Renderer {",
+                        "public:",
+                        "    void Draw();",
+                        "};",
+                        "void Blend(Renderer& renderer)",
+                        "{",
+                        "    renderer.Draw();",
+                        "    Helper();",
+                        "    std::move(renderer);",
+                        "}",
+                        "}",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
             subprocess.run(
                 [
                     sys.executable,
@@ -80,6 +101,7 @@ class FunctionGraphMcpSmokeTests(unittest.TestCase):
             tools = CodeIndexTools(project_root=project_root, index_root=index_root)
             try:
                 paint_symbol_id = self._definition_symbol_id(tools, "Paint")
+                blend_symbol_id = self._definition_symbol_id(tools, "Blend")
 
                 graph = self._call_json(
                     tools.get_function_body_graph(
@@ -103,6 +125,31 @@ class FunctionGraphMcpSmokeTests(unittest.TestCase):
                     tools.get_call_xrefs_from(
                         {
                             "symbolId": paint_symbol_id,
+                            "responseFormat": "minified",
+                        }
+                    )
+                )
+                blend_graph = self._call_json(
+                    tools.get_function_body_graph(
+                        {
+                            "symbolId": blend_symbol_id,
+                            "mode": "compute_if_missing",
+                            "responseFormat": "minified",
+                        }
+                    )
+                )
+                blend_xrefs = self._call_json(
+                    tools.get_call_xrefs_from(
+                        {
+                            "symbolId": blend_symbol_id,
+                            "responseFormat": "minified",
+                        }
+                    )
+                )
+                blend_neighborhood = self._call_json(
+                    tools.get_symbol_neighborhood(
+                        {
+                            "symbolId": blend_symbol_id,
                             "responseFormat": "minified",
                         }
                     )
@@ -139,6 +186,13 @@ class FunctionGraphMcpSmokeTests(unittest.TestCase):
         self.assertEqual(cache_only["fingerprints"]["graph"], graph["fingerprints"]["graph"])
         self.assertGreaterEqual(xrefs["returnedEdges"], 3)
         self.assertFalse(xrefs["behaviorClaimsAllowed"])
+        blend_statuses = {edge["toText"]: edge["resolutionStatus"] for edge in blend_graph["edges"]}
+        self.assertIn(blend_statuses["renderer.Draw"], {"probable", "unresolved"})
+        self.assertIn(blend_statuses["Helper"], {"exact", "probable", "ambiguous"})
+        self.assertEqual(blend_statuses["std::move"], "external")
+        self.assertGreaterEqual(blend_xrefs["returnedEdges"], 2)
+        self.assertEqual(blend_neighborhood["target"]["symbolId"], blend_symbol_id)
+        self.assertFalse(blend_neighborhood["behaviorClaimsAllowed"])
         self.assertNotIn("reads_data_candidate", filtered_edge_kinds)
         self.assertNotIn("writes_data_candidate", filtered_edge_kinds)
         self.assertNotIn("control_flow_marker", filtered_edge_kinds)

--- a/tests/test_cpp_function_graph_resolver.py
+++ b/tests/test_cpp_function_graph_resolver.py
@@ -339,6 +339,68 @@ class FunctionGraphResolverTests(unittest.TestCase):
         self.assertGreater(edges[0].candidates[0]["score"], edges[0].candidates[1]["score"])
         self.assertIn("arity_match", edges[0].candidates[0]["basis"])
 
+    def test_unqualified_lookup_prefers_same_namespace_over_fallbacks(self) -> None:
+        visibility = FunctionVisibilityContext(
+            file_id="file-1",
+            file_path="paint.cpp",
+            function_symbol_id="fn-paint",
+            current_namespace=("App",),
+            current_class_symbol_id=None,
+            current_class_name=None,
+            imported_modules=("App.Core",),
+            visible_exported_symbols=(
+                {
+                    "symbolId": "fn-module-helper",
+                    "type": "function",
+                    "shortName": "Helper",
+                    "qualifiedName": "Shared::Helper",
+                    "container": "Shared",
+                },
+            ),
+            same_file_symbols=(
+                {
+                    "symbolId": "fn-app-helper",
+                    "type": "function",
+                    "shortName": "Helper",
+                    "qualifiedName": "App::Helper",
+                    "container": "App",
+                },
+                {
+                    "symbolId": "fn-other-helper",
+                    "type": "function",
+                    "shortName": "Helper",
+                    "qualifiedName": "Other::Helper",
+                    "container": "Other",
+                },
+            ),
+            same_file_data=(),
+            member_data=(),
+            using_directives=(
+                {
+                    "namespace": "Other",
+                },
+            ),
+        )
+        ast = FunctionAstExtract(
+            symbol_id="fn-paint",
+            source_fingerprint="sha256:source",
+            parser_id="fixture",
+            parser_version="v1",
+            extractor_version="v1",
+            calls=(
+                {
+                    "callee": "Helper",
+                    "callKind": "unqualified",
+                },
+            ),
+        )
+
+        edges = resolve_function_graph_edges(ast_extract=ast, visibility=visibility)
+
+        self.assertEqual(edges[0].resolution_status, "probable")
+        self.assertEqual(edges[0].to_symbol_id, "fn-app-helper")
+        self.assertIn("same_namespace", edges[0].basis)
+
     def test_member_call_uses_local_type_hint_as_probable_candidate(self) -> None:
         visibility = FunctionVisibilityContext(
             file_id="file-1",


### PR DESCRIPTION
## Summary
- merge/sync the PR #6 follow-up trail in work logs, then continue on a fresh branch
- improve lightweight parser coverage for template calls, lambdas, chained-result member calls, and macro-like call noise
- expand real-index MCP smoke to a multi-file temp project with multiple computed graphs
- bump resolver ranking to v0.3 and document cache maintenance UX without adding public MCP tools

## Tests
- `python -m py_compile src/indexer/cpp_function_graph_extract.py src/indexer/cpp_function_graph_resolver.py tests/test_cpp_function_graph_extract.py tests/test_cpp_function_graph_mcp_smoke.py tests/test_cpp_function_graph_resolver.py`
- `python -m unittest tests.test_cpp_function_graph_extract tests.test_cpp_function_graph_resolver tests.test_cpp_function_graph_mcp_smoke`
- `python -m unittest discover -s tests -p "test_*.py"`
- `git diff --check`
- `git diff --cached --check`

## Notes
- No new public MCP tools.
- Tree-sitter remains optional/gated.
- Function graph output remains structural-only with `claimStrength=source_structure_allowed` and `behaviorClaimsAllowed=false`.
- Unrelated local dirty files were not included.