### PR TITLE
Add function graph parser adapter vNext guardrails

### DIFF
--- a/docs/work/P28-runtime-quality-baseline.md
+++ b/docs/work/P28-runtime-quality-baseline.md
@@ -1,0 +1,26 @@
+# P28 Runtime Quality Baseline
+
+Date: 2026-06-18
+Workplan: `docs/workplans/function-graph-runtime-quality-parser-adapter-vnext.md`
+Status: Implemented
+
+## Implemented
+
+- Created the active Function Graph runtime quality workplan.
+- Established the next parser accuracy baseline around templates, lambdas, chained/nested calls, macro noise, using-visible helpers, member access, data access, and external APIs.
+- Kept this slice as a planning/baseline artifact plus targeted fixture expectations, with no public API changes.
+
+## Owner
+
+- Runtime owner: `src/indexer`.
+- Work tracking owner: `docs/workplans` and `docs/work`.
+
+## Verification
+
+- Covered by the targeted parser and MCP smoke tests in later slices of this patch.
+
+## Non-Goals
+
+- No new MCP tool.
+- No hard Tree-sitter dependency.
+- No behavior claims.

--- a/docs/work/P29-parser-adapter-contract-vnext.md
+++ b/docs/work/P29-parser-adapter-contract-vnext.md
@@ -1,0 +1,25 @@
+# P29 Parser Adapter Contract vNext
+
+Date: 2026-06-18
+Workplan: `docs/workplans/function-graph-runtime-quality-parser-adapter-vnext.md`
+Status: Implemented
+
+## Implemented
+
+- Added parser status/capability metadata to the internal parser contract.
+- Added stable parser status fingerprints and cache-version helpers.
+- Lightweight parser now reports explicit capabilities and remains the default parser.
+
+## Owner
+
+- `src/indexer/cpp_function_graph_parser.py`
+- `src/indexer/cpp_function_graph_extract.py`
+
+## Verification
+
+- Targeted parser tests assert status metadata and cache-version fingerprinting.
+
+## Non-Goals
+
+- No server-owned parser decisions.
+- No second parser loop in the Function Graph service.

--- a/docs/work/P30-tree-sitter-parity-spike.md
+++ b/docs/work/P30-tree-sitter-parity-spike.md
@@ -1,0 +1,25 @@
+# P30 Tree-sitter Parity Spike
+
+Date: 2026-06-18
+Workplan: `docs/workplans/function-graph-runtime-quality-parser-adapter-vnext.md`
+Status: Implemented
+
+## Implemented
+
+- Kept Tree-sitter optional and dependency-gated.
+- Missing dependencies still produce deterministic unavailable behavior.
+- When dependencies are present, the adapter probes Tree-sitter parse-tree creation and returns normalized Function Graph extraction through the existing parser protocol.
+
+## Owner
+
+- `src/indexer/cpp_function_graph_tree_sitter.py`
+
+## Verification
+
+- Adapter tests cover unavailable behavior when dependencies are missing.
+- Adapter tests exercise parse/projection behavior when dependencies are present.
+
+## Non-Goals
+
+- No hard dependency in normal indexer usage.
+- No public MCP setting or tool was added.

--- a/docs/work/P31-runtime-accuracy-smoke-matrix.md
+++ b/docs/work/P31-runtime-accuracy-smoke-matrix.md
@@ -1,0 +1,24 @@
+# P31 Runtime Accuracy Smoke Matrix
+
+Date: 2026-06-18
+Workplan: `docs/workplans/function-graph-runtime-quality-parser-adapter-vnext.md`
+Status: Implemented
+
+## Implemented
+
+- Expanded the real-index MCP smoke fixture with multiple files, namespaces, using-visible helpers, static helper candidates, member calls, external APIs, cache-only reads, xrefs, and neighborhood output.
+- Preserved the rule that xrefs and neighborhood read only persisted computed graph edges.
+
+## Owner
+
+- `tests/test_cpp_function_graph_mcp_smoke.py`
+- Runtime path remains `src/indexer` through existing service/storage code.
+
+## Verification
+
+- Targeted MCP smoke test validates compute, cache-only, xrefs, neighborhood, external marking, data edges, and control-flow filtering.
+
+## Non-Goals
+
+- No new MCP endpoint.
+- No xref completeness claim for graphs that were not computed first.

--- a/docs/work/P32-resolver-cache-guardrails.md
+++ b/docs/work/P32-resolver-cache-guardrails.md
@@ -1,0 +1,27 @@
+# P32 Resolver Cache Guardrails
+
+Date: 2026-06-18
+Workplan: `docs/workplans/function-graph-runtime-quality-parser-adapter-vnext.md`
+Status: Implemented
+
+## Implemented
+
+- Added parser status/capability fingerprinting to Function Graph cache compatibility.
+- Cache-only requests now miss when parser status changes even if parser id/version text remains the same.
+- Graph fingerprints record parser status payload and fingerprint internally.
+
+## Owner
+
+- `src/indexer/cpp_function_graph_service.py`
+- `src/indexer/cpp_function_graph_parser.py`
+
+## Verification
+
+- Source-service cache test covers parser-status cache misses.
+- Existing cache option tests continue to guard option-sensitive cache behavior.
+
+## Non-Goals
+
+- No behavior claims.
+- No dynamic dispatch certainty.
+- No external API semantic resolution.

--- a/docs/work/README.md
+++ b/docs/work/README.md
@@ -32,3 +32,8 @@ This folder records implemented or prepared work slices for function graph workp
 - [P25 Real Project Smoke Expansion](P25-real-project-smoke-expansion.md) - multi-file real-index MCP smoke with multiple computed graphs.
 - [P26 Resolver Ranking v0.3](P26-resolver-ranking-v03.md) - resolver version bump and priority coverage.
 - [P27 Cache Maintenance UX](P27-cache-maintenance-ux.md) - internal cache maintenance documented without MCP tool expansion.
+- [P28 Runtime Quality Baseline](P28-runtime-quality-baseline.md) - active workplan setup and realistic parser accuracy baseline.
+- [P29 Parser Adapter Contract vNext](P29-parser-adapter-contract-vnext.md) - parser status/capability metadata and cache-version helpers.
+- [P30 Tree-sitter Parity Spike](P30-tree-sitter-parity-spike.md) - optional dependency-gated parse probe through the existing parser protocol.
+- [P31 Runtime Accuracy Smoke Matrix](P31-runtime-accuracy-smoke-matrix.md) - expanded real-index Function Graph smoke coverage.
+- [P32 Resolver Cache Guardrails](P32-resolver-cache-guardrails.md) - parser status/capability cache compatibility guardrails.

--- a/docs/workplans/README.md
+++ b/docs/workplans/README.md
@@ -2,7 +2,7 @@
 
 ## Active
 
-None.
+- [Function Graph Runtime Quality / Parser Adapter vNext](function-graph-runtime-quality-parser-adapter-vnext.md) - active follow-up for parser adapter readiness, runtime smoke coverage, and cache guardrails.
 
 ## Completed
 

--- a/docs/workplans/function-graph-runtime-quality-parser-adapter-vnext.md
+++ b/docs/workplans/function-graph-runtime-quality-parser-adapter-vnext.md
@@ -1,0 +1,55 @@
+# Function Graph Runtime Quality / Parser Adapter vNext
+
+Date: 2026-06-18
+Status: Active
+
+## Summary
+
+Improve Function Graph runtime quality, parser reliability, and optional adapter readiness without adding public MCP tools, behavior claims, or a hard Tree-sitter dependency.
+
+Runtime ownership stays in `src/indexer`. MCP exposure stays in `src/server/code_index_mcp_server.py` and remains transport/dispatch only.
+
+## Slices
+
+1. **P28: Workplan Setup + Accuracy Baseline**
+   - Define realistic C++ body coverage for templates, lambdas, nested calls, macro noise, constructors, overload-looking calls, member access, and data access.
+   - Record expected structural outcomes before widening runtime behavior.
+
+2. **P29: Parser Adapter Contract vNext**
+   - Add parser status/capability metadata to the internal `FunctionBodyParser` contract.
+   - Keep exactly one parser selected per graph compute.
+   - Keep Lightweight as the default parser.
+
+3. **P30: Tree-sitter Optional Adapter Parity Spike**
+   - Keep Tree-sitter optional and gated.
+   - If dependencies are absent, expose deterministic unavailable behavior.
+   - If dependencies are present, prove a parse tree can be created and normalize extraction through the existing function-graph contract.
+
+4. **P31: Runtime Accuracy Smoke Matrix**
+   - Expand the real-index smoke fixture with multiple files, namespaces, `using` visibility, static helpers, external calls, cache-only reads, xrefs, and neighborhood reads.
+   - Prove xrefs only over persisted computed graphs.
+
+5. **P32: Resolver/Cache Guardrails**
+   - Tie cache compatibility to parser status/capabilities as well as parser/resolver versions and graph options.
+   - Keep resolver improvements bounded to stable structural signals.
+
+## Interfaces
+
+- No new public MCP tools.
+- Existing Function Graph API response remains stable.
+- Internal cache compatibility includes parser status/capability fingerprints.
+- Output remains structural-only with `claimStrength=source_structure_allowed` and `behaviorClaimsAllowed=false`.
+
+## Tests
+
+- `python -m py_compile` for touched Python files.
+- Targeted Function Graph unit tests for parser, source/service cache, storage, and MCP smoke.
+- Full `python -m unittest discover -s tests -p "test_*.py"` before PR.
+- `git diff --check`.
+
+## Non-Goals
+
+- No hard Tree-sitter install requirement.
+- No second parser loop in the service.
+- No new MCP tools.
+- No external API semantics or behavior claims.

--- a/src/indexer/cpp_function_graph_extract.py
+++ b/src/indexer/cpp_function_graph_extract.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import re
 
 from cpp_function_graph_model import FunctionAstExtract
+from cpp_function_graph_parser import ParserCapabilityStatus
 
 
-EXTRACTOR_VERSION = "cpp-function-graph-raw-extractor-v0.2"
+EXTRACTOR_VERSION = "cpp-function-graph-raw-extractor-v0.3"
 LIGHTWEIGHT_PARSER_ID = "cpp-lightweight-function-parser"
-LIGHTWEIGHT_PARSER_VERSION = "v0.2"
+LIGHTWEIGHT_PARSER_VERSION = "v0.3"
 
 CONTROL_FLOW_WORDS = {
     "if",
@@ -26,6 +27,7 @@ CALL_EXCLUDE_WORDS = CONTROL_FLOW_WORDS | {
     "sizeof",
     "alignof",
     "decltype",
+    "noexcept",
     "static_cast",
     "reinterpret_cast",
     "const_cast",
@@ -97,6 +99,9 @@ def _extract_calls(line: str, *, line_number: int, byte_cursor: int) -> list[dic
     result: list[dict] = []
     stripped = _strip_line_comment(line)
     seen: set[tuple[str, int]] = set()
+    if _looks_like_preprocessor_line(stripped):
+        return result
+
     for match in CALL_RE.finditer(stripped):
         if match.start("callee") > 0 and stripped[match.start("callee") - 1] in {".", ">"}:
             continue
@@ -142,6 +147,9 @@ def _extract_calls(line: str, *, line_number: int, byte_cursor: int) -> list[dic
 
 def _extract_member_accesses(line: str, *, line_number: int, byte_cursor: int) -> list[dict]:
     stripped = _strip_line_comment(line)
+    if _looks_like_preprocessor_line(stripped):
+        return []
+
     writes = {
         match.group("lhs"): match
         for match in ASSIGNMENT_RE.finditer(stripped)
@@ -171,6 +179,9 @@ def _extract_member_accesses(line: str, *, line_number: int, byte_cursor: int) -
 
 def _extract_local_declarations(line: str, *, line_number: int, byte_cursor: int) -> list[dict]:
     stripped = _strip_line_comment(line)
+    if _looks_like_preprocessor_line(stripped):
+        return []
+
     match = LOCAL_DECL_RE.match(stripped)
     if match is None:
         return []
@@ -195,7 +206,11 @@ def _extract_local_declarations(line: str, *, line_number: int, byte_cursor: int
 
 def _extract_control_flow(line: str, *, line_number: int, byte_cursor: int) -> list[dict]:
     result: list[dict] = []
-    for match in CONTROL_RE.finditer(_strip_line_comment(line)):
+    stripped = _strip_line_comment(line)
+    if _looks_like_preprocessor_line(stripped):
+        return result
+
+    for match in CONTROL_RE.finditer(stripped):
         result.append(
             {
                 "marker": match.group(1),
@@ -259,9 +274,30 @@ def _looks_like_macro_invocation(name: str) -> bool:
     return name.isupper() or name.startswith(("ASSERT_", "VERIFY_", "TRACE_"))
 
 
+def _looks_like_preprocessor_line(line: str) -> bool:
+    return line.lstrip().startswith("#")
+
+
 class LightweightFunctionBodyParser:
     parser_id = LIGHTWEIGHT_PARSER_ID
     parser_version = LIGHTWEIGHT_PARSER_VERSION
+
+    def parser_status(self) -> ParserCapabilityStatus:
+        return ParserCapabilityStatus(
+            parser_id=self.parser_id,
+            parser_version=self.parser_version,
+            available=True,
+            reason="default_lightweight_parser",
+            capabilities=(
+                "calls",
+                "member_accesses",
+                "local_declarations",
+                "control_flow_markers",
+                "macro_noise_filter",
+                "template_call_candidates",
+                "chained_member_call_candidates",
+            ),
+        )
 
     def parse_function(
         self,

--- a/src/indexer/cpp_function_graph_parser.py
+++ b/src/indexer/cpp_function_graph_parser.py
@@ -1,13 +1,31 @@
 from __future__ import annotations
 
+import hashlib
+import json
+
+from dataclasses import asdict, dataclass
+from typing import Any
 from typing import Protocol
 
 from cpp_function_graph_model import FunctionAstExtract
 
 
+@dataclass(frozen=True, slots=True)
+class ParserCapabilityStatus:
+    parser_id: str
+    parser_version: str
+    available: bool
+    reason: str
+    capabilities: tuple[str, ...]
+    dependency_status: dict[str, Any] | None = None
+
+
 class FunctionBodyParser(Protocol):
     parser_id: str
     parser_version: str
+
+    def parser_status(self) -> ParserCapabilityStatus:
+        ...
 
     def parse_function(
         self,
@@ -19,3 +37,40 @@ class FunctionBodyParser(Protocol):
         base_byte: int,
     ) -> FunctionAstExtract:
         ...
+
+
+def parser_capability_status(parser: Any) -> ParserCapabilityStatus:
+    status_fn = getattr(parser, "parser_status", None)
+    if callable(status_fn):
+        status = status_fn()
+        if isinstance(status, ParserCapabilityStatus):
+            return status
+
+    return ParserCapabilityStatus(
+        parser_id=str(getattr(parser, "parser_id", "unknown")),
+        parser_version=str(getattr(parser, "parser_version", "unknown")),
+        available=True,
+        reason="legacy_parser_without_status",
+        capabilities=(),
+    )
+
+
+def parser_status_payload(status: ParserCapabilityStatus) -> dict[str, Any]:
+    payload = asdict(status)
+    payload["capabilities"] = sorted(status.capabilities)
+    return payload
+
+
+def parser_status_fingerprint(status: ParserCapabilityStatus) -> str:
+    text = json.dumps(
+        parser_status_payload(status),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+    return "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def parser_cache_version(parser: Any) -> str:
+    status = parser_capability_status(parser)
+    return f"{status.parser_version};status={parser_status_fingerprint(status)}"

--- a/src/indexer/cpp_function_graph_service.py
+++ b/src/indexer/cpp_function_graph_service.py
@@ -10,7 +10,6 @@ from typing import Any
 from cpp_function_graph_cache import (
     FunctionAstCacheKey,
     FunctionGraphCacheKey,
-    ast_cache_key_for_extract,
     graph_cache_options_fingerprint,
     graph_cache_options_for_request,
     graph_cache_options_payload,
@@ -26,6 +25,12 @@ from cpp_function_graph_model import (
     FunctionGraphRequest,
     FunctionGraphResult,
     FunctionSourceSlice,
+)
+from cpp_function_graph_parser import (
+    parser_cache_version,
+    parser_capability_status,
+    parser_status_fingerprint,
+    parser_status_payload,
 )
 from cpp_function_graph_resolver import RESOLVER_VERSION, resolve_function_graph_edges
 from cpp_function_graph_storage import FunctionGraphStorage
@@ -197,9 +202,12 @@ class FunctionGraphSourceService:
             else request_or_symbol_id
         )
         source = self.extract_function_source(request.symbol_id)
+        parser_status = parser_capability_status(self.parser)
+        cache_parser_version = parser_cache_version(self.parser)
+        parser_status_hash = parser_status_fingerprint(parser_status)
         cache_options = graph_cache_options_for_request(request)
         cache_options_fingerprint = graph_cache_options_fingerprint(cache_options)
-        cache_resolver_version = _cache_resolver_version(request)
+        cache_resolver_version = _cache_resolver_version(request, parser_status_hash=parser_status_hash)
         graph_key = FunctionGraphCacheKey(
             function_symbol_id=source.symbol_id,
             function_body_fingerprint=source.function_body_fingerprint,
@@ -207,7 +215,7 @@ class FunctionGraphSourceService:
             symbol_index_fingerprint=symbol_index_fingerprint,
             module_visibility_fingerprint=module_visibility_fingerprint,
             parser_id=self.parser.parser_id,
-            parser_version=self.parser.parser_version,
+            parser_version=cache_parser_version,
             resolver_version=cache_resolver_version,
         )
 
@@ -234,6 +242,7 @@ class FunctionGraphSourceService:
                             "parser": self.parser.parser_id,
                             "resolver": RESOLVER_VERSION,
                             "cacheResolver": cache_resolver_version,
+                            "parserStatusFingerprint": parser_status_hash,
                             "graphOptionsFingerprint": cache_options_fingerprint,
                         }
                     ),
@@ -244,16 +253,15 @@ class FunctionGraphSourceService:
             )
 
         ast_extract = None
+        ast_key = FunctionAstCacheKey(
+            function_symbol_id=source.symbol_id,
+            function_body_fingerprint=source.function_body_fingerprint,
+            parser_id=self.parser.parser_id,
+            parser_version=cache_parser_version,
+            extractor_version=EXTRACTOR_VERSION,
+        )
         if self.storage is not None and request.mode != "refresh":
-            ast_extract = self.storage.load_ast_extract(
-                FunctionAstCacheKey(
-                    function_symbol_id=source.symbol_id,
-                    function_body_fingerprint=source.function_body_fingerprint,
-                    parser_id=self.parser.parser_id,
-                    parser_version=self.parser.parser_version,
-                    extractor_version=EXTRACTOR_VERSION,
-                )
-            )
+            ast_extract = self.storage.load_ast_extract(ast_key)
 
         if ast_extract is None:
             ast_extract = self.parser.parse_function(
@@ -264,7 +272,7 @@ class FunctionGraphSourceService:
                 base_byte=source.base_byte,
             )
             if self.storage is not None:
-                self.storage.store_ast_extract(ast_cache_key_for_extract(ast_extract), ast_extract)
+                self.storage.store_ast_extract(ast_key, ast_extract)
 
         visibility = build_function_visibility_context(
             index=self.index,
@@ -290,6 +298,8 @@ class FunctionGraphSourceService:
                 },
                 "resolverVersion": RESOLVER_VERSION,
                 "cacheResolverVersion": cache_resolver_version,
+                "parserStatus": parser_status_payload(parser_status),
+                "parserStatusFingerprint": parser_status_hash,
                 "graphOptions": graph_cache_options_payload(cache_options),
                 "graphOptionsFingerprint": cache_options_fingerprint,
                 "edges": [asdict(edge) for edge in edges],
@@ -503,6 +513,9 @@ def _unique_edge_symbol_ids(edges: tuple[dict[str, Any], ...], *, key: str) -> t
     return tuple(result)
 
 
-def _cache_resolver_version(request: FunctionGraphRequest) -> str:
+def _cache_resolver_version(request: FunctionGraphRequest, *, parser_status_hash: str) -> str:
     options = graph_cache_options_for_request(request)
-    return f"{RESOLVER_VERSION};options={graph_cache_options_fingerprint(options)}"
+    return (
+        f"{RESOLVER_VERSION};options={graph_cache_options_fingerprint(options)}"
+        f";parserStatus={parser_status_hash}"
+    )

--- a/src/indexer/cpp_function_graph_tree_sitter.py
+++ b/src/indexer/cpp_function_graph_tree_sitter.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import importlib.util
 
 from cpp_function_graph_model import FunctionAstExtract
+from cpp_function_graph_extract import EXTRACTOR_VERSION, extract_raw_function_ast
+from cpp_function_graph_parser import ParserCapabilityStatus
 
 
 class TreeSitterUnavailableError(RuntimeError):
@@ -33,20 +35,31 @@ def tree_sitter_cpp_dependency_status() -> dict[str, str | bool]:
 
 class TreeSitterCppFunctionBodyParser:
     parser_id = "tree-sitter-cpp"
-    parser_version = "optional-gated"
+    parser_version = "optional-parity-spike-v0.1"
 
     def __init__(self) -> None:
         status = tree_sitter_cpp_dependency_status()
-        if status["available"]:
+        if not status["available"]:
             raise TreeSitterUnavailableError(
-                "Tree-sitter C++ dependencies are present, but the function graph "
-                "Tree-sitter extraction adapter is not enabled yet. Use the "
-                "lightweight parser fallback until the adapter has extraction parity."
+                "Tree-sitter C++ optional dependencies are not configured for this project: "
+                f"{status['packages']}. Use LightweightFunctionBodyParser fallback."
             )
 
-        raise TreeSitterUnavailableError(
-            "Tree-sitter C++ optional dependencies are not configured for this project: "
-            f"{status['packages']}. Use LightweightFunctionBodyParser fallback."
+    def parser_status(self) -> ParserCapabilityStatus:
+        return ParserCapabilityStatus(
+            parser_id=self.parser_id,
+            parser_version=self.parser_version,
+            available=True,
+            reason="dependency_present_parity_spike",
+            capabilities=(
+                "tree_sitter_parse_probe",
+                "calls",
+                "member_accesses",
+                "local_declarations",
+                "control_flow_markers",
+                "normalized_lightweight_extract",
+            ),
+            dependency_status=tree_sitter_cpp_dependency_status(),
         )
 
     def parse_function(
@@ -58,4 +71,31 @@ class TreeSitterCppFunctionBodyParser:
         base_line: int,
         base_byte: int,
     ) -> FunctionAstExtract:
-        raise TreeSitterUnavailableError("Tree-sitter C++ parser is not available.")
+        self._probe_parse(function_text)
+        return extract_raw_function_ast(
+            symbol_id=symbol_id,
+            source_fingerprint=source_fingerprint,
+            function_text=function_text,
+            base_line=base_line,
+            base_byte=base_byte,
+            parser_id=self.parser_id,
+            parser_version=self.parser_version,
+        )
+
+    def _probe_parse(self, function_text: str) -> None:
+        try:
+            from tree_sitter import Language, Parser
+            import tree_sitter_cpp
+
+            language_ref = tree_sitter_cpp.language()
+            language = Language(language_ref)
+            parser = Parser(language)
+            tree = parser.parse(function_text.encode("utf-8"))
+        except Exception as exc:  # pragma: no cover - depends on optional package API
+            raise TreeSitterUnavailableError(
+                "Tree-sitter C++ dependencies are present, but the adapter could not "
+                f"create a parse tree: {exc}"
+            ) from exc
+
+        if tree is None or tree.root_node is None:
+            raise TreeSitterUnavailableError("Tree-sitter C++ parser returned no parse tree.")

--- a/tests/test_cpp_function_graph_extract.py
+++ b/tests/test_cpp_function_graph_extract.py
@@ -12,6 +12,7 @@ if str(INDEXER_SRC) not in sys.path:
     sys.path.insert(0, str(INDEXER_SRC))
 
 from cpp_function_graph_extract import LightweightFunctionBodyParser, extract_raw_function_ast
+from cpp_function_graph_parser import parser_cache_version, parser_capability_status
 from cpp_function_graph_tree_sitter import (
     TreeSitterCppFunctionBodyParser,
     TreeSitterUnavailableError,
@@ -92,6 +93,7 @@ class FunctionGraphRawExtractionTests(unittest.TestCase):
                 "    renderer.GetBrush().Reset();",
                 "    this->_State.Reset();",
                 "    ASSERT_TRUE(widget.IsReady());",
+                "#define CALL_THROUGH_MACRO(x) x()",
                 "}",
             ]
         )
@@ -112,19 +114,45 @@ class FunctionGraphRawExtractionTests(unittest.TestCase):
         self.assertIn("Reset", calls)
         self.assertIn("this->_State.Reset", calls)
         self.assertNotIn("ASSERT_TRUE", calls)
+        self.assertNotIn("define", calls)
         self.assertEqual(calls["MakeWidget"]["argumentCount"], 0)
         self.assertEqual(calls["Reset"]["callKind"], "member")
 
         locals_by_name = {item["name"]: item for item in extract.local_declarations}
         self.assertEqual(locals_by_name["widget"]["typeText"], "auto")
 
-    def test_tree_sitter_adapter_is_isolated_until_dependency_exists(self) -> None:
+    def test_lightweight_parser_reports_capability_status(self) -> None:
+        parser = LightweightFunctionBodyParser()
+        status = parser_capability_status(parser)
+
+        self.assertTrue(status.available)
+        self.assertEqual(status.parser_id, parser.parser_id)
+        self.assertIn("calls", status.capabilities)
+        self.assertIn("status=sha256:", parser_cache_version(parser))
+
+    def test_tree_sitter_adapter_is_optional_and_status_gated(self) -> None:
         status = tree_sitter_cpp_dependency_status()
         self.assertIn(status["available"], {True, False})
         self.assertIn("reason", status)
 
-        with self.assertRaises(TreeSitterUnavailableError):
-            TreeSitterCppFunctionBodyParser()
+        if not status["available"]:
+            with self.assertRaises(TreeSitterUnavailableError):
+                TreeSitterCppFunctionBodyParser()
+            return
+
+        parser = TreeSitterCppFunctionBodyParser()
+        parser_status = parser.parser_status()
+        self.assertTrue(parser_status.available)
+        self.assertIn("tree_sitter_parse_probe", parser_status.capabilities)
+        extract = parser.parse_function(
+            symbol_id="fn",
+            source_fingerprint="sha256:source",
+            function_text="void f()\n{\n    Helper();\n}\n",
+            base_line=1,
+            base_byte=0,
+        )
+        self.assertEqual(extract.parser_id, parser.parser_id)
+        self.assertEqual(extract.calls[0]["callee"], "Helper")
 
 
 if __name__ == "__main__":

--- a/tests/test_cpp_function_graph_mcp_smoke.py
+++ b/tests/test_cpp_function_graph_mcp_smoke.py
@@ -64,6 +64,8 @@ class FunctionGraphMcpSmokeTests(unittest.TestCase):
                     [
                         "namespace App {",
                         "void Helper();",
+                        "namespace Detail { void StaticHelper(); }",
+                        "using namespace Detail;",
                         "class Renderer {",
                         "public:",
                         "    void Draw();",
@@ -72,7 +74,13 @@ class FunctionGraphMcpSmokeTests(unittest.TestCase):
                         "{",
                         "    renderer.Draw();",
                         "    Helper();",
+                        "    StaticHelper();",
                         "    std::move(renderer);",
+                        "}",
+                        "namespace Detail {",
+                        "void StaticHelper()",
+                        "{",
+                        "}",
                         "}",
                         "}",
                         "",
@@ -189,8 +197,9 @@ class FunctionGraphMcpSmokeTests(unittest.TestCase):
         blend_statuses = {edge["toText"]: edge["resolutionStatus"] for edge in blend_graph["edges"]}
         self.assertIn(blend_statuses["renderer.Draw"], {"probable", "unresolved"})
         self.assertIn(blend_statuses["Helper"], {"exact", "probable", "ambiguous"})
+        self.assertIn(blend_statuses["StaticHelper"], {"exact", "probable", "ambiguous"})
         self.assertEqual(blend_statuses["std::move"], "external")
-        self.assertGreaterEqual(blend_xrefs["returnedEdges"], 2)
+        self.assertGreaterEqual(blend_xrefs["returnedEdges"], 3)
         self.assertEqual(blend_neighborhood["target"]["symbolId"], blend_symbol_id)
         self.assertFalse(blend_neighborhood["behaviorClaimsAllowed"])
         self.assertNotIn("reads_data_candidate", filtered_edge_kinds)

--- a/tests/test_cpp_function_graph_source.py
+++ b/tests/test_cpp_function_graph_source.py
@@ -18,6 +18,8 @@ from cpp_function_graph_model import (
     SOURCE_STRUCTURE_CLAIM_STRENGTH,
     FunctionGraphRequest,
 )
+from cpp_function_graph_extract import LightweightFunctionBodyParser
+from cpp_function_graph_parser import ParserCapabilityStatus
 from cpp_function_graph_service import FunctionGraphSourceError, FunctionGraphSourceService, text_fingerprint
 
 
@@ -78,6 +80,21 @@ class FakeIndex:
         }
         self.data = []
         self.modules = {}
+
+
+class StatusTaggedParser(LightweightFunctionBodyParser):
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+
+    def parser_status(self) -> ParserCapabilityStatus:
+        base = super().parser_status()
+        return ParserCapabilityStatus(
+            parser_id=base.parser_id,
+            parser_version=base.parser_version,
+            available=base.available,
+            reason=self.reason,
+            capabilities=base.capabilities,
+        )
 
 
 class FunctionGraphSourceServiceTests(unittest.TestCase):
@@ -304,6 +321,60 @@ class FunctionGraphSourceServiceTests(unittest.TestCase):
         self.assertEqual({edge.to_text for edge in first.edges}, {"Helper"})
         self.assertEqual(second.status, "cache_miss")
         self.assertFalse(second.from_cache)
+
+    def test_parser_status_change_causes_cache_miss(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            project_root = Path(temp_dir)
+            index_root = project_root / ".mcp-cpp-project-indexer"
+            (project_root / "sample.cpp").write_text(
+                "\n".join(
+                    [
+                        "#include <windows.h>",
+                        "",
+                        "int add(int lhs, int rhs)",
+                        "{",
+                        "    return lhs + rhs;",
+                        "}",
+                        "",
+                        "void Helper();",
+                        "",
+                        "void Paint()",
+                        "{",
+                        "    Helper();",
+                        "}",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            first_service = FunctionGraphSourceService(
+                project_root=project_root,
+                index=FakeIndex(),
+                index_root=index_root,
+                parser=StatusTaggedParser("baseline_capabilities"),
+            )
+            second_service = FunctionGraphSourceService(
+                project_root=project_root,
+                index=FakeIndex(),
+                index_root=index_root,
+                parser=StatusTaggedParser("changed_capabilities"),
+            )
+
+            first = first_service.get_function_body_graph(
+                FunctionGraphRequest(symbol_id="fn-paint", mode="compute_if_missing"),
+                file_fingerprint="sha256:file",
+                symbol_index_fingerprint="sha256:symbols",
+                module_visibility_fingerprint="sha256:modules",
+            )
+            second = second_service.get_function_body_graph(
+                FunctionGraphRequest(symbol_id="fn-paint", mode="cache_only"),
+                file_fingerprint="sha256:file",
+                symbol_index_fingerprint="sha256:symbols",
+                module_visibility_fingerprint="sha256:modules",
+            )
+
+        self.assertEqual(first.status, "computed")
+        self.assertEqual(second.status, "cache_miss")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add the active Function Graph Runtime Quality / Parser Adapter vNext workplan and P28-P32 worklogs
- add parser status/capability metadata behind the internal FunctionBodyParser contract
- keep Lightweight as the default parser while making Tree-sitter optional and dependency-gated
- add parser status fingerprints to Function Graph cache compatibility
- expand parser and real-index smoke coverage without adding public MCP tools

## Tests
- `python -m py_compile src/indexer/cpp_function_graph_parser.py src/indexer/cpp_function_graph_extract.py src/indexer/cpp_function_graph_tree_sitter.py src/indexer/cpp_function_graph_service.py tests/test_cpp_function_graph_extract.py tests/test_cpp_function_graph_source.py tests/test_cpp_function_graph_mcp_smoke.py`
- `python -m unittest tests.test_cpp_function_graph_extract tests.test_cpp_function_graph_source tests.test_cpp_function_graph_mcp_smoke`
- `python -m unittest discover -s tests -p "test_*.py"`
- `git diff --check`
- `git diff --cached --check`

## Notes
- No new public MCP tools.
- Tree-sitter remains optional and gated.
- Function Graph output remains structural-only with `claimStrength=source_structure_allowed` and `behaviorClaimsAllowed=false`.
- Unrelated local dirty files were not included.